### PR TITLE
removed atexit.register(_umount) to skip umount after each storage ac…

### DIFF
--- a/mtda/sdmux/helpers/image.py
+++ b/mtda/sdmux/helpers/image.py
@@ -20,7 +20,6 @@ class Image(SdMuxController):
         self.isfuse = False
         self.isloop = False
         self.lock = threading.Lock()
-        atexit.register(self._umount)
 
     def _close(self):
         self.mtda.debug(3, "sdmux.helpers.image._close()")


### PR DESCRIPTION
…tions

fixes : umount is not required for all exists ex. _mount mounpoint will be unmounted before
performing any file operation or storage update

Signed-off-by: Mayuri Mohite <MayuriMohan_Mohite@mentor.com>