### PR TITLE
mtda/main: rename 'str' keyboard_write() function parameter

### DIFF
--- a/mtda/main.py
+++ b/mtda/main.py
@@ -376,13 +376,13 @@ class MultiTenantDeviceAccess:
         self.mtda.debug(3, "env_set(): %s" % str(result))
         return result
 
-    def keyboard_write(self, str, session=None):
+    def keyboard_write(self, input_str, session=None):
         self.mtda.debug(3, "main.keyboard_write()")
 
         self._session_check(session)
         result = None
         if self.keyboard is not None:
-            result = self.keyboard.write(str)
+            result = self.keyboard.write(input_str)
 
         self.mtda.debug(3, "main.keyboard_write(): %s" % str(result))
         return result


### PR DESCRIPTION
The keyboard_write() function has a parameter named 'str', which
creates conflict with the built-in str() method. So renaming it
to something else solves the following error.

Current Log:
```
mtda@mtda:~$ mtda-cli keyboard write test
Traceback (most recent call last):
  File "/usr/bin/mtda-cli", line 767, in <module>
    app.main()
  File "/usr/bin/mtda-cli", line 753, in main
    status = cmds[cmd](stuff)
  File "/usr/bin/mtda-cli", line 367, in keyboard_cmd
    cmds[cmd](args)
  File "/usr/bin/mtda-cli", line 355, in keyboard_write
    self.client().keyboard_write(args[0])
  File "/usr/lib/python3/dist-packages/mtda/client.py", line 118, in keyboard_write
    return self._impl.keyboard_write(data, self._session)
  File "/usr/lib/python3/dist-packages/mtda/main.py", line 384, in keyboard_write
    self.mtda.debug(3, "main.keyboard_write(): %s" % str(result))
TypeError: 'str' object is not callable
```