### PR TITLE
mtda/main: Stop self._session_timer thread before exiting

### DIFF
--- a/mtda/main.py
+++ b/mtda/main.py
@@ -1337,7 +1337,7 @@ class MultiTenantDeviceAccess:
 
         # Stop the timer thread on ctrl+C
         def signal_handler(signum, frame):
-            print("Exiting, Thank you for using MTDA ...")
+            self.mtda.debug(2, "process interrupted, shutting down...")
             self._session_timer.cancel()
 
         signal.signal(signal.SIGINT, signal_handler)

--- a/mtda/main.py
+++ b/mtda/main.py
@@ -1335,6 +1335,12 @@ class MultiTenantDeviceAccess:
         self._session_timer = mtda.utils.RepeatTimer(60, self._session_check)
         self._session_timer.start()
 
+        # Stop the timer thread on ctrl+C
+        def signal_handler(signum, frame):
+            print("Exiting, Thank you for using MTDA ...")
+            self._session_timer.cancel()
+
+        signal.signal(signal.SIGINT, signal_handler)
         return True
 
     def _session_check(self, session=None):


### PR DESCRIPTION
Currently the self._session_timer thread is not stopped while exiting hence the following error is observe while invoking `ctrl+c` 
```
^CException ignored in: <module 'threading' from '/usr/lib/python3.9/threading.py'>
Traceback (most recent call last):
  File "/usr/lib/python3.9/threading.py", line 1428, in _shutdown
    lock.acquire()
KeyboardInterrupt:
```
This PR stops the thread and exits the application without any errors while using `ctrl+c`

I have also added exit message
```
^CExiting, Thank you for using MTDA ...
```

This PR also fixes [https://github.com/siemens/mtda/issues/67](url) partially.