### PR TITLE
mtda/power: add support for USB HID relay (usbrelay driver)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ X-Python3-Version: >= 3.7
 Package: mtda
 Architecture: all
 Multi-Arch: foreign
-Depends: wamerican, ${misc:Depends}, ${python3:Depends}
+Depends: usbrelay, wamerican, ${misc:Depends}, ${python3:Depends}
 Description: Multi-Tenant Device Access
  Multi-Tenant Device Access (or MTDA for short) is a relatively
  small Python application and library acting as an interface

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -76,8 +76,8 @@ General settings
     may be selected with ``variant``.
 
   * ``variant``: string [required]
-      Select a power variant from ``aviosys_8800``, ``gpio``, ``pduclient`` and
-      ``qemu``.
+      Select a power variant from ``aviosys_8800``, ``gpio``, ``pduclient``, 
+      ``qemu`` and ``usbrelay``.
 
 * ``remote``: section [optional]
     Specify the host and ports to connect to when using a MTDA client (such as
@@ -279,6 +279,16 @@ The following settings are supported:
 
 * ``watchdog``: string [optional]
     Name of the watchdog driver provided by QEMU/KVM for the selected machine.
+
+``usbrelay`` driver settings
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``usbrelay`` driver may be used to control USB HID relays attached to the
+system running the MTDA agent. The following settings are supported:
+
+* ``lines``: string [required]
+    Comma separated list of lines to toggle relays driving power of
+    the device.
 
 Shared device settings
 ----------------------

--- a/mtda.ini
+++ b/mtda.ini
@@ -105,6 +105,7 @@ time-until = login:
 #    - gpio
 #    - pduclient
 #    - qemu
+#    - usbrelay
 # ---------------------------------------------------------------------------
 # Note: this section is ignored when connecting to a remote agent
 # ---------------------------------------------------------------------------
@@ -124,6 +125,9 @@ variant=aviosys_8800
 # machine=pc
 # memory=2048
 # storage=ssd.img
+
+# variant=usbrelay
+# lines=959BI_1
 
 # ---------------------------------------------------------------------------
 # Shared Storage settings

--- a/mtda/power/usbrelay.py
+++ b/mtda/power/usbrelay.py
@@ -1,0 +1,128 @@
+# ---------------------------------------------------------------------------
+# usbrelay power driver for MTDA
+# ---------------------------------------------------------------------------
+#
+# This software is a part of MTDA.
+# Copyright (C) 2021 Siemens Digital Industries Software
+#
+# ---------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------
+
+# System imports
+import abc
+import os
+import re
+import subprocess
+import threading
+
+# Local imports
+from mtda.power.controller import PowerController
+
+
+class UsbRelayPowerController(PowerController):
+
+    def __init__(self, mtda):
+        self.dev = None
+        self.ev = threading.Event()
+        self.exe = "/usr/bin/usbrelay"
+        self.mtda = mtda
+        self.lines = []
+
+    def configure(self, conf):
+        if 'lines' in conf:
+            self.lines = conf['lines'].split(',')
+
+    def probe(self):
+        if self.lines is None:
+            raise ValueError("usbrelay: 'lines' not configured!")
+
+        if os.path.exists(self.exe) is False:
+            raise ValueError("{0} was not found!".format(self.exe))
+
+        # Make sure all configured lines were detected
+        statuses = self._get_lines()
+        for line in self.lines:
+            if line not in statuses:
+                raise ValueError("usbrelay: {0} not detected!")
+
+    def command(self, args):
+        return False
+
+    def on(self):
+        if self._set_lines("1") is False:
+            return False
+        status = self.status()
+        if status == self.POWER_ON:
+            self.ev.set()
+            return True
+        return False
+
+    def off(self):
+        if self._set_lines("0") is False:
+            return False
+        status = self.status()
+        if status == self.POWER_OFF:
+            self.ev.clear()
+            return True
+        return False
+
+    def status(self):
+        statuses = self._get_lines()
+        first = True
+        result = self.POWER_UNSURE
+        for line in self.lines:
+            value = statuses[line]
+            if value == '1':
+                value = self.POWER_ON
+            else:
+                value = self.POWER_OFF
+            self.mtda.debug(3, "power.usbrelay.status: "
+                               "line {0} is {1}".format(line, value))
+            if first is True:
+                first = False
+                result = value
+            elif value != result:
+                result = self.POWER_UNSURE
+        return result
+
+    def toggle(self):
+        s = self.status()
+        if s == self.POWER_OFF:
+            self.on()
+        else:
+            self.off()
+        return self.status()
+
+    def wait(self):
+        while self.status() != self.POWER_ON:
+            self.ev.wait()
+
+    def _get_lines(self):
+        result = {}
+        try:
+            lines = subprocess.check_output(
+                    [self.exe]).decode("utf-8").splitlines()
+            for line in lines:
+                m = re.match(r"(\w+)=([01])", line)
+                if m is not None:
+                    name = m[1]
+                    value = m[2]
+                    result[name] = value
+        except subprocess.CalledProcessError:
+            result = None
+
+        return result
+
+    def _set_lines(self, value):
+        try:
+            for line in self.lines:
+                subprocess.check_call(
+                        [self.exe, "{0}={1}".format(line, value)])
+        except subprocess.CalledProcessError:
+            return False
+        return True
+
+
+def instantiate(mtda):
+    return UsbRelayPowerController(mtda)


### PR DESCRIPTION
Add a usbrelay driver to drive relays exposed to the host via a
USB HID interface and the usbrelay tool. The driver expects a list
of relays (lines) to drive.

Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>