### PR TITLE
docs: minor corrections

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -208,7 +208,7 @@ FriendlyARM for makers, hobbyists and fans.
 It is powered by an Allwinner H3 (Cortex A7), has a microSD slot, a microUSB
 OTG port, a USB-Host Type A port, an Ethernet port and GPIO pins.
 
-Debian (buster) will be loaded on the microSD card and will include the MTDA
+Debian (bullseye) will be loaded on the microSD card and will include the MTDA
 agent. It will communicate with its clients over Ethernet. An electric relay
 will be controlled via a GPIO line in order to drive power for our Device Under
 Test. Communication with that device will be achieved via the USB OTG port

--- a/docs/fixtures.rst
+++ b/docs/fixtures.rst
@@ -52,14 +52,13 @@ agent to enable the functions listed above::
 
     [storage]
     variant=usbf
-    device=/dev/sda
 
     [keyboard]
     variant=hid
     device=/dev/hidg0
 
 If the ``storage`` function was enabled, ``/etc/mtda/usb-functions`` should
-be created and also specify the block device to be used::
+be created and specify the block device to be used::
 
     MASS_STORAGE_FILE=/dev/sda
 


### PR DESCRIPTION
The NanoPI NEO image is now based on Debian bullseye.

The block device should be specified in /etc/mtda/usb-functions when
using the usbf storage driver.

Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>