### PR TITLE
setup.py: needs zeroconf to be installed to run mtda-cli on host

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ and testers to remotely access and control hardware devices.
         "psutil",
         "requests",
         "zerorpc>=0.6.0",
-        "zstandard>=0.14"
+        "zstandard>=0.14",
+	"zeroconf>=0.28.6"
     ],
 )


### PR DESCRIPTION
Closes: #132
 
Signed-off-by: Richa Bharti <Richa_Bharti@mentor.com>