### PR TITLE
setup.py: replace tab with space

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,6 @@ and testers to remotely access and control hardware devices.
         "requests",
         "zerorpc>=0.6.0",
         "zstandard>=0.14",
-	"zeroconf>=0.28.6"
+        "zeroconf>=0.28.6"
     ],
 )


### PR DESCRIPTION
Fixes the below pycodestyle issue:
setup.py:57:1: E101 indentation contains mixed spaces and tabs
setup.py:57:1: W191 indentation contains tabs

Signed-off-by: Vijai Kumar K <Vijaikumar_Kanagarajan@mentor.com>