### PR TITLE
meta-isar/conf: set PREFERRED_PROVIDER for u-boot-nanopi-r1

### DIFF
--- a/meta-isar/conf/machine/nanopi-r1.conf
+++ b/meta-isar/conf/machine/nanopi-r1.conf
@@ -14,5 +14,6 @@ WKS_FILE ?= "nanopi-r1.wks.in"
 
 IMAGE_INSTALL += "u-boot-script"
 IMAGER_INSTALL += "u-boot-nanopi-r1"
+PREFERRED_PROVIDER_u-boot-nanopi-r1 = "u-boot-nanopi-r1"
 
 IMAGE_INSTALL += " firmware-nanopi-r1"


### PR DESCRIPTION
Kill a build warning about PREFERRED_PROVIDER_u-boot-nanopi-r1
not being set.

Fixes: #142
Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>