### PR TITLE
Revert "meta-isar/conf: use IMAGE_FSTYPES instead of IMAGE_TYPE"

### DIFF
--- a/meta-isar/conf/machine/nanopi-r1.conf
+++ b/meta-isar/conf/machine/nanopi-r1.conf
@@ -9,7 +9,7 @@ DISTRO_ARCH ?= "armhf"
 
 KERNEL_NAME ?= "armmp"
 
-IMAGE_FSTYPES ?= "wic-img"
+IMAGE_TYPE ?= "wic-img"
 WKS_FILE ?= "nanopi-r1.wks.in"
 
 IMAGE_INSTALL += "u-boot-script"


### PR DESCRIPTION
In 3d6d41d6, we reverted to a version of ISAR that doesnot have the
IMAGE_FSTYPES support.

Fixes wic-img generation in nanopi-r1.