### PR TITLE
power/qemu: support additional system drives

### DIFF
--- a/configs/qemu.ini
+++ b/configs/qemu.ini
@@ -39,7 +39,8 @@ machine=pc
 memory=2048
 pflash_ro=/usr/share/OVMF/OVMF_CODE.fd
 pflash_rw=/var/lib/mtda/qemu-ovmf-vars.fd
-storage=/var/lib/mtda/ssd.img
+storage.0=/var/lib/mtda/ssd.img
+#storage.1=/var/lib/mtda/extra-ssd.img
 watchdog=i6300esb
 
 # ---------------------------------------------------------------------------

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -297,7 +297,8 @@ The following settings are supported:
     Path to the read-write firmware flash.
 
 * ``storage``: string [optional]
-    Path to the emulated machine storage.
+    Path to the emulated machine storage. Use ``storage.0``, ``storage.1``,
+    etc. if more than one system drive should be emulated.
 
 * ``swtpm``: string [optional]
     Path to the ``swtpm`` binary to support emulation of a TPM device.


### PR DESCRIPTION
Support emulation of multiple system drives with "storage.<N>"
configuration entries. If both "storage" and "storage.0" are
set, "storage.0" will be used.

Fixes: #161
Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>