### PR TITLE
Prepare for Isar 0.8

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,8 +4,9 @@ Priority: extra
 Maintainer: Cedric Hombourger <cedric.hombourger@siemens.com>
 Build-Depends: debhelper (>=10) | dh-systemd,
                dh-python,
-               python3-setuptools,
-               python3-all
+               libpython3-all-dev,
+               python3-all-dev,
+               python3-setuptools
 Standards-Version: 4.5.0 
 Homepage: https://github.com/siemens/mtda
 X-Python3-Version: >= 3.7

--- a/meta-isar/recipes-bsp/u-boot/u-boot-nanopi-r1_2021.10.bb
+++ b/meta-isar/recipes-bsp/u-boot/u-boot-nanopi-r1_2021.10.bb
@@ -11,7 +11,7 @@ require u-boot-${PV}.inc
 DEBIAN_BUILD_DEPENDS_append = ",libssl-dev:native,libssl-dev"
 
 # Python packages needed during the build
-DEBIAN_BUILD_DEPENDS_append = ",python3-distutils,python3-pkg-resources,python3-dev:native,swig:native"
+DEBIAN_BUILD_DEPENDS_append = ",python3-distutils,python3-pkg-resources,python3-all-dev:native,swig"
 
 U_BOOT_BIN = "u-boot-sunxi-with-spl.bin"
 U_BOOT_CONFIG = "nanopi_r1_defconfig"

--- a/meta-isar/recipes-python/compression/files/zstandard-0.14.0/debian/changelog
+++ b/meta-isar/recipes-python/compression/files/zstandard-0.14.0/debian/changelog
@@ -1,3 +1,9 @@
+zstandard (0.14.0-5) unstable; urgency=medium
+
+  * Build-Depends against python3-all-dev packages
+
+ -- Cedric Hombourger <cedric.hombourger@siemens.com>  Sat, 17 Jan 2022 23:11:00 +0100
+
 zstandard (0.14.0-4) unstable; urgency=medium
 
   * Amend Build-Depends to support cross-compilation

--- a/meta-isar/recipes-python/compression/files/zstandard-0.14.0/debian/control
+++ b/meta-isar/recipes-python/compression/files/zstandard-0.14.0/debian/control
@@ -4,9 +4,9 @@ Priority: optional
 Maintainer: Cedric Hombourger <cedric.hombourger@siemens.com>
 Build-Depends: debhelper (>=10),
                dh-python,
-               libpython3-dev,
-               python3-dev:any,
-               python3-setuptools:native
+               libpython3-all-dev,
+               python3-all-dev,
+               python3-setuptools
 Standards-Version: 4.5.0
 Homepage: https://pypi.org/project/zstandard
 Rules-Requires-Root: no

--- a/meta-isar/recipes-python/crypto/files/curve25519-donna-1.3/debian/changelog
+++ b/meta-isar/recipes-python/crypto/files/curve25519-donna-1.3/debian/changelog
@@ -1,3 +1,9 @@
+curve25519-donna (1.3-5) unstable; urgency=medium
+
+  * Build-Depends against python3-all-dev
+
+ -- Cedric Hombourger <cedric.hombourger@siemens.com>  Mon, 17 Jan 2022 23:14:00 +0100
+
 curve25519-donna (1.3-4) unstable; urgency=medium
 
   * Fix Build-Depends to support cross-compiling.

--- a/meta-isar/recipes-python/crypto/files/curve25519-donna-1.3/debian/control
+++ b/meta-isar/recipes-python/crypto/files/curve25519-donna-1.3/debian/control
@@ -4,9 +4,9 @@ Priority: optional
 Maintainer: Cedric Hombourger <cedric.hombourger@siemens.com>
 Build-Depends: debhelper (>=10),
                dh-python,
-               libpython3-dev,
-               python3-dev:any,
-               python3-setuptools:native
+               libpython3-all-dev,
+               python3-all-dev,
+               python3-setuptools
 Standards-Version: 4.5.0
 Homepage: https://pypi.org/project/curve25519-donna
 Rules-Requires-Root: no

--- a/meta-isar/recipes-python/crypto/files/ed25519-1.5/debian/changelog
+++ b/meta-isar/recipes-python/crypto/files/ed25519-1.5/debian/changelog
@@ -1,3 +1,9 @@
+ed25519 (1.5-5) unstable; urgency=medium
+
+  * Build-Depends against python3-all-dev
+
+ -- Cedric Hombourger <cedric.hombourger@siemens.com>  Mon, 17 Jan 2022 23:15:00 +0100
+
 ed25519 (1.5-4) unstable; urgency=medium
 
   * Fix Build-Depends to support cross-compiling.

--- a/meta-isar/recipes-python/crypto/files/ed25519-1.5/debian/control
+++ b/meta-isar/recipes-python/crypto/files/ed25519-1.5/debian/control
@@ -4,9 +4,9 @@ Priority: optional
 Maintainer: Cedric Hombourger <cedric.hombourger@siemens.com>
 Build-Depends: debhelper (>=10),
                dh-python,
-               libpython3-dev,
-               python3-dev:any,
-               python3-setuptools:native
+               libpython3-all-dev,
+               python3-all-dev,
+               python3-setuptools
 Standards-Version: 4.5.0
 Homepage: https://pypi.org/project/ed25519/
 Rules-Requires-Root: no

--- a/meta-isar/recipes-python/net/files/hap-python-3.0/debian/changelog
+++ b/meta-isar/recipes-python/net/files/hap-python-3.0/debian/changelog
@@ -1,3 +1,9 @@
+hap-python (3.0-4) unstable; urgency=medium
+
+  * Build-Depends against python3-all0-dev
+
+ -- Cedric Hombourger <cedric.hombourger@siemens.com>  Mon, 17 Jan 2022 23:15:00 +0100
+
 hap-python (3.0-3) unstable; urgency=medium
 
   * Fix Build-Depends to support cross-compiling.

--- a/meta-isar/recipes-python/net/files/hap-python-3.0/debian/control
+++ b/meta-isar/recipes-python/net/files/hap-python-3.0/debian/control
@@ -4,9 +4,9 @@ Priority: optional
 Maintainer: Cedric Hombourger <cedric.hombourger@siemens.com>
 Build-Depends: debhelper (>=10),
                dh-python,
-               libpython3-dev,
-               python3-dev:any,
-               python3-setuptools:native
+               libpython3-all-dev,
+               python3-all-dev,
+               python3-setuptools
 Standards-Version: 4.5.0
 Homepage: https://github.com/ikalchev/HAP-python
 Rules-Requires-Root: no

--- a/meta-isar/recipes-python/net/files/zeroconf-0.28.6/debian/changelog
+++ b/meta-isar/recipes-python/net/files/zeroconf-0.28.6/debian/changelog
@@ -1,3 +1,9 @@
+python-zeroconf (0.28.6-4) unstable; urgency=medium
+
+  * Build-Depends against python3-all-dev
+
+ -- Cedric Hombourger <cedric.hombourger@siemens.com>  Mon, 17 Jan 2022 23:16:00 +0100
+
 python-zeroconf (0.28.6-3) unstable; urgency=medium
 
   * Amend Build-Depends to support cross-compilation

--- a/meta-isar/recipes-python/net/files/zeroconf-0.28.6/debian/control
+++ b/meta-isar/recipes-python/net/files/zeroconf-0.28.6/debian/control
@@ -4,9 +4,9 @@ Priority: optional
 Maintainer: Cedric Hombourger <cedric.hombourger@siemens.com>
 Build-Depends: debhelper (>=10),
                dh-python,
-               libpython3-dev,
-               python3-dev:any,
-               python3-setuptools:native
+               libpython3-all-dev,
+               python3-all-dev,
+               python3-setuptools
 Standards-Version: 4.5.0
 Homepage: https://pypi.org/project/zeroconf
 Rules-Requires-Root: no

--- a/meta-isar/recipes-python/qt5/files/py3qterm-0.4/debian/changelog
+++ b/meta-isar/recipes-python/qt5/files/py3qterm-0.4/debian/changelog
@@ -1,3 +1,9 @@
+py3qterm (0.4-4) testing; urgency=low
+
+  * Build-Depends against python3-all-dev
+
+ -- Cedric Hombourger <cedric.hombourger@siemens.com>  Mon, 17 Jan 2022 23:17:00 +0100
+
 py3qterm (0.4-3) testing; urgency=low
 
   * Amend Build-Depends to support cross-compilation

--- a/meta-isar/recipes-python/qt5/files/py3qterm-0.4/debian/control
+++ b/meta-isar/recipes-python/qt5/files/py3qterm-0.4/debian/control
@@ -4,9 +4,9 @@ Priority: extra
 Maintainer: Cedric Hombourger <cedric.hombourger@siemens.com>
 Build-Depends: debhelper (>=10),
                dh-python,
-               libpython3-dev,
-               python3-dev:any,
-               python3-setuptools:native
+               libpython3-all-dev,
+               python3-all-dev,
+               python3-setuptools
 Standards-Version: 4.5.0
 Homepage: https://gitlab.com/mikeramsey/py3qtermwidget
 X-Python3-Version: >= 3.7

--- a/meta-isar/recipes-python/zerorpc/files/zerorpc-0.6.3/debian/changelog
+++ b/meta-isar/recipes-python/zerorpc/files/zerorpc-0.6.3/debian/changelog
@@ -1,3 +1,9 @@
+zerorpc-python (0.6.3-4) testing; urgency=low
+
+  * Build-Depends against python3-all-dev
+
+ -- Cedric Hombourger <cedric.hombourger@siemens.com>  Mon, 17 Jan 2022 23:18:00 +0100
+
 zerorpc-python (0.6.3-3) testing; urgency=low
 
   * Amend Build-Depends to support cross-compilation

--- a/meta-isar/recipes-python/zerorpc/files/zerorpc-0.6.3/debian/control
+++ b/meta-isar/recipes-python/zerorpc/files/zerorpc-0.6.3/debian/control
@@ -4,9 +4,9 @@ Priority: extra
 Maintainer: Cedric Hombourger <cedric.hombourger@siemens.com>
 Build-Depends: debhelper (>=10),
                dh-python,
-               libpython3-dev,
-               python3-dev:any,
-               python3-setuptools:native
+               libpython3-all-dev,
+               python3-all-dev,
+               python3-setuptools
 Standards-Version: 4.5.0
 Homepage: https://github.com/0rpc/zerorpc-python
 X-Python3-Version: >= 3.7


### PR DESCRIPTION
Resolved do_install_builddeps failures when building against Isar v0.8-rc1 by having Python packages Build-Depend on python3-all-dev

Note: the actual switch to Isar version 0.8 is deferred to v0.16