### PR TITLE
main: start with board off and storage on target

### DIFF
--- a/mtda/main.py
+++ b/mtda/main.py
@@ -1381,6 +1381,10 @@ class MultiTenantDeviceAccess:
                                                          self._session_check)
             self._session_timer.start()
 
+        # Start from a known state
+        self._target_off()
+        self.storage_to_target()
+
         return True
 
     def stop(self):


### PR DESCRIPTION
Put test fixture like power controller or storage muxes into a known
state when MTDA is started.

Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>