### PR TITLE
www: allow remote access to the console via web browsers

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -141,6 +141,18 @@ General settings
       Select a ``video`` variant: ``mjpg_streamer`` is the only supported
       driver at this time.
 
+* ``www``: section [optional]
+   A lightweight web server will be started when this section is present.
+   The following parameters may be customized:
+
+  * ``port``: integer [optional]
+      Port to run the HTTP service on (defaults to 5000).
+
+  * ``host``: string [optional]
+      Host address to listen on. This defaults to ``127.0.0.1`` to only
+      accept connections from the machine running the MTDA service.
+      Change to ``0.0.0.0`` to accept connections from anywhere.
+
 Console and Monitor settings
 ----------------------------
 

--- a/mtda.ini
+++ b/mtda.ini
@@ -74,6 +74,17 @@ session =  5
 # prefix = ctrl-a
 
 # ---------------------------------------------------------------------------
+# Web service settings
+# ---------------------------------------------------------------------------
+# Uncomment the following to enable remote access to the console using a web
+# browser. Use 0.0.0.0 as the host address to allow access from anywhere (use
+# with caution).
+# ---------------------------------------------------------------------------
+# [www]
+# host = 127.0.0.1
+# port = 5000
+
+# ---------------------------------------------------------------------------
 # Console settings
 # ---------------------------------------------------------------------------
 # Set "variant" to specify how to access the console interface of the device.

--- a/mtda/console/logger.py
+++ b/mtda/console/logger.py
@@ -21,7 +21,8 @@ import zmq
 class ConsoleLogger:
 
     def __init__(self, mtda, console, socket=None,
-                 power_controller=None, topic=b'CON'):
+                 power_controller=None, topic=b'CON',
+                 www=None):
         self.mtda = mtda
         self.console = console
         self._prompt = "=> "
@@ -39,6 +40,7 @@ class ConsoleLogger:
         self.timestamps = False
         self._time_from = None
         self._time_until = None
+        self._www = www
 
     def start(self):
         self.rx_alive = True
@@ -214,6 +216,8 @@ class ConsoleLogger:
                 # Write to stdout if received are not pushed to the network
                 sys.stdout.buffer.write(data)
                 sys.stdout.buffer.flush()
+            if self._www is not None:
+                self._www.write(self.topic, data.decode('utf-8', 'ignore'))
 
     # Print a string to the console (local or remote)
     def print(self, data):

--- a/mtda/constants.py
+++ b/mtda/constants.py
@@ -22,6 +22,8 @@ class DEFAULTS:
     LOCK_TIMEOUT = 5
     POWER_TIMEOUT = 60
     SESSION_TIMEOUT = 5
+    WWW_HOST = '127.0.0.1'
+    WWW_PORT = 5000
 
 
 class IMAGE(Enum):

--- a/mtda/templates/index.html
+++ b/mtda/templates/index.html
@@ -1,0 +1,54 @@
+<!---
+Copyright (C) 2022 Siemens Digital Industries Software
+SPDX-License-Identifier: MIT
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Multi-Tenant Device Access</title>
+    <style>
+      html {
+        font-family: arial;
+      }
+    </style>
+    <link rel="stylesheet" href="https://unpkg.com/xterm@4.11.0/css/xterm.css"/>
+  </head>
+  <body>
+    <span style="font-size: 1.4em">Multi-Tenant Device Access</span>
+    <div style="width: 80%; height: calc(100% - 50px)" id="console"></div>
+    <span style="font-size: small">status:
+      <span style="font-size: small" id="status">connecting...</span>
+    </span>
+    <script src="https://unpkg.com/xterm@4.11.0/lib/xterm.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.1/socket.io.min.js"></script>
+    <script>
+      const term = new Terminal({
+        cursorBlink: true,
+        macOptionIsMeta: true,
+        scrollback: true,
+      });
+      term.open(document.getElementById("console"));
+      term.resize(80, 25);
+      term.onData((data) => {
+        socket.emit("console-input", { input: data });
+      });
+
+      const socket = io.connect("/mtda");
+      const status = document.getElementById("status");
+
+      socket.on("console-output", function (data) {
+        term.write(data.output);
+      });
+
+      socket.on("connect", () => {
+        status.innerHTML =
+          '<span style="background-color: lightgreen;">connected</span>';
+      });
+
+      socket.on("disconnect", () => {
+        status.innerHTML =
+          '<span style="background-color: #ff8383;">disconnected</span>';
+      });
+    </script>
+  </body>
+</html>

--- a/mtda/www.py
+++ b/mtda/www.py
@@ -1,0 +1,69 @@
+# ---------------------------------------------------------------------------
+# Web service for MTDA
+# ---------------------------------------------------------------------------
+#
+# This software is a part of MTDA.
+# Copyright (C) 2022 Siemens Digital Industries Software
+#
+# ---------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------
+
+from flask import Flask, render_template
+from flask_socketio import SocketIO
+import threading
+
+import mtda.constants as CONSTS
+
+app = Flask("mtda")
+app.config["mtda"] = None
+socket = SocketIO(app)
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@socket.on("connect", namespace="/mtda")
+def connect():
+    mtda = app.config['mtda']
+    if mtda is not None:
+        data = mtda.console_dump()
+        socket.emit("console-output", {"output": data}, namespace="/mtda")
+
+
+@socket.on("console-input", namespace="/mtda")
+def console_input(data):
+    mtda = app.config['mtda']
+    if mtda is not None:
+        mtda.console_send(data['input'], raw=False, session=None)
+
+
+class Service:
+    def __init__(self, mtda):
+        self.mtda = mtda
+        self._host = CONSTS.DEFAULTS.WWW_HOST
+        self._port = CONSTS.DEFAULTS.WWW_PORT
+        app.config['mtda'] = mtda
+
+    def configure(self, conf):
+        if 'host' in conf:
+            self._host = conf['host']
+        if 'port' in conf:
+            self._port = int(conf['port'])
+
+    def run(self):
+        return socket.run(app, debug=False, use_reloader=False,
+                          port=self._port, host=self._host)
+
+    def start(self):
+        self._thread = threading.Thread(target=self.run)
+        return self._thread.start()
+
+    def stop(self):
+        socket.stop()
+
+    def write(self, topic, data):
+        if topic == CONSTS.CHANNEL.CONSOLE:
+            socket.emit("console-output", {"output": data}, namespace="/mtda")

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     version=__version__,
     scripts=['mtda-cli', 'mtda-ui'],
     packages=find_packages(exclude=["demos"]),
+    package_data={'mtda': ['templates/*.html']},
     author='Cedric Hombourger',
     author_email='cedric.hombourger@siemens.com',
 
@@ -46,6 +47,8 @@ and testers to remotely access and control hardware devices.
 
     install_requires=[
         "docker",
+        "flask_socketio",
+        "gevent-websocket",
         "pyserial>=2.6",
         "python-daemon>=2.0",
         "pyusb>=1.0",


### PR DESCRIPTION
Make ConsoleLogger send output to a Flask-SocketIO socket that may
be consumed by an xterm.js-based terminal in the browser.

Closes: #184
Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>