### PR TITLE
meta-isar/recipes-python: build HEAD of mtda

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+mtda (0.16-0) testing; urgency=medium
+
+  * Development version
+
+ -- Cedric Hombourger <cedric.hombourger@siemens.com>  Fri, 04 Feb 2022 08:00:00 +0100
+
 mtda (0.15-1) testing; urgency=medium
 
   [ Cedric Hombourger ]

--- a/meta-isar/recipes-python/mtda/mtda_git.bb
+++ b/meta-isar/recipes-python/mtda/mtda_git.bb
@@ -8,7 +8,7 @@
 inherit dpkg
 
 SRC_URI += "git://git@github.com/siemens/mtda.git;protocol=https;branch=master"
-SRCREV   = "4925f8f1bc1214f78777a7648eac0ac183f11232"
+SRCREV   = "${AUTOREV}"
 S        = "${WORKDIR}/git"
 
 DEPENDS += "zerorpc-python zstandard"

--- a/mtda/__version__.py
+++ b/mtda/__version__.py
@@ -11,4 +11,4 @@
 
 __license__ = 'MIT'
 __copyright__ = 'Copyright (C) 2022 Siemens Digital Industries Software'
-__version__ = '0.15'
+__version__ = '0.16'


### PR DESCRIPTION
Make it easier to build MTDA images with the latest changes by
using SRCREV="${AUTOREV}" in the bitbake recipe. Releases will
continue to use a fixed git commit hash. The Debian changelog
uses a "-0" revision to flag development builds.

Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>