### PR TITLE
power/docker: make sure we do not pull all images

### DIFF
--- a/mtda/power/docker.py
+++ b/mtda/power/docker.py
@@ -46,7 +46,7 @@ class DockerPowerController(PowerController):
         result = None
         atexit.register(self._stop)
         self._client = docker.from_env()
-        self._client.images.pull(self._image)
+        self._client.images.pull(self._image, all_tags=False)
         result = self._start()
 
         self.mtda.debug(3, "power.docker.probe(): {}".format(result))


### PR DESCRIPTION
Docker's images.pull() defaults to all_tags=False. There are
however reports that MTDA would fetch all images on start-up.
Call pull() with all_tags explicitly set to False.

Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>