### PR TITLE
power/docker: Fix pulling all tags

### DIFF
--- a/mtda/power/docker.py
+++ b/mtda/power/docker.py
@@ -46,7 +46,12 @@ class DockerPowerController(PowerController):
         result = None
         atexit.register(self._stop)
         self._client = docker.from_env()
-        self._client.images.pull(self._image, all_tags=False)
+        # python3-docker version <= 4.4 pulls all tags by default.
+        # set tag explicitly to latest if none specified.
+        image = self._image.split(":")
+        distro = image[0]
+        version = image[1] if len(image) > 1 else "latest"
+        self._client.images.pull(distro, tag=version)
         result = self._start()
 
         self.mtda.debug(3, "power.docker.probe(): {}".format(result))


### PR DESCRIPTION
python3-docker < 4.4.0 pulls all tags by default.

Explicitly pass the tag to fetch to fix the issue.

This solution should work with the python3-docker > 4.4.0 as well.

Ref: https://github.com/docker/docker-py/commit/daa9f179c3a3e666c0b2cbccebd88756bc30d058

Fixes the below commit
70c0a67bf28f72de92525bfb4bd4c9f89b28013e

Reported-by: Onkar Bokshe <OnkarSurendrakumar_Bokshe@mentor.com>
Signed-off-by: Vijai Kumar K <Vijaikumar_Kanagarajan@mentor.com>