### PR TITLE
meta-isar/recipes-core: Initialize ISAR_RELEASE_CMD

### DIFF
--- a/meta-isar/recipes-core/images/mtda-image.inc
+++ b/meta-isar/recipes-core/images/mtda-image.inc
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: MIT
 # ---------------------------------------------------------------------------
 
+ISAR_RELEASE_CMD = "git -C ${LAYERDIR_mtda} describe --tags --dirty --match 'v[0-9].[0-9]*'"
+
 # Default device/file to use for our USB Mass Storage Gadget
 MTDA_MASS_STORAGE_FILE ??= "mmcblk0"
 


### PR DESCRIPTION
Resolves the related warning and delivers the required information to
/etc/os-release.

BTW, you likely also want to stop using the exemplary isar-image-base or at least set an own image DESCRIPTION.