### PR TITLE
storage/qemu: create backing file when 'file' is not set

### DIFF
--- a/mtda/storage/qemu.py
+++ b/mtda/storage/qemu.py
@@ -35,12 +35,12 @@ class QemuController(Image):
         result = None
         if 'file' in conf:
             self.file = os.path.realpath(conf['file'])
-            d = os.path.dirname(self.file)
-            os.makedirs(d, mode=0o755, exist_ok=True)
-            if os.path.exists(self.file) is False:
-                sparse = pathlib.Path(self.file)
-                sparse.touch()
-                os.truncate(str(sparse), 8*1024*1024*1024)
+        d = os.path.dirname(self.file)
+        os.makedirs(d, mode=0o755, exist_ok=True)
+        if os.path.exists(self.file) is False:
+            sparse = pathlib.Path(self.file)
+            sparse.touch()
+            os.truncate(str(sparse), 8*1024*1024*1024)
         if 'name' in conf:
             self.name = conf['name']
 


### PR DESCRIPTION
A backing file should be created using the default name when a
custom 'file' isn't specified in the configuration.

Fixes: 3da7a12
Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>