### PR TITLE
mtda-cli: use 'localhost' as default remote

### DIFF
--- a/mtda-cli
+++ b/mtda-cli
@@ -35,7 +35,7 @@ class Application:
 
     def __init__(self):
         self.agent = None
-        self.remote = None
+        self.remote = "localhost"
         self.logfile = "/var/log/mtda.log"
         self.pidfile = "/var/run/mtda.pid"
         self.exiting = False


### PR DESCRIPTION
Clients should always connect to the daemon/service. Assume "localhost"
when no remote is specified on the command line instead of silently
failing.

Closes: #219
Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>