### PR TITLE
meta-isar/recipes-bsp: suffix u-boot-script with DISTRO and MACHINE

### DIFF
--- a/meta-isar/conf/machine/nanopi-r1.conf
+++ b/meta-isar/conf/machine/nanopi-r1.conf
@@ -12,7 +12,6 @@ KERNEL_NAME ?= "armmp"
 IMAGE_FSTYPES ?= "wic-img"
 WKS_FILE ?= "nanopi-r1.wks.in"
 
-IMAGE_INSTALL += "u-boot-script"
 IMAGER_INSTALL += "u-boot-nanopi-r1"
 PREFERRED_PROVIDER_u-boot-nanopi-r1 = "u-boot-nanopi-r1"
 

--- a/meta-isar/recipes-bsp/u-boot-script/u-boot-script_%.bbappend
+++ b/meta-isar/recipes-bsp/u-boot-script/u-boot-script_%.bbappend
@@ -5,11 +5,5 @@
 # SPDX-License-Identifier: MIT
 # ---------------------------------------------------------------------------
 
-DISTRO_ARCH ?= "armhf"
-
-KERNEL_NAME ?= "armmp"
-
-IMAGE_FSTYPES ?= "wic-img"
-WKS_FILE ?= "beaglebone-black.wks.in"
-
-IMAGER_INSTALL += "u-boot-omap"
+# Suffix the u-boot-script package to get unique packages in our binary feeds
+PN .= "-${DISTRO}-${MACHINE}"

--- a/meta-isar/recipes-core/images/mtda-image.bb
+++ b/meta-isar/recipes-core/images/mtda-image.bb
@@ -1,6 +1,6 @@
 # ---------------------------------------------------------------------------
 # This Isar layer is part of MTDA
-# Copyright (C) 2021 Siemens Digital Industries Software
+# Copyright (C) 2022 Siemens Digital Industries Software
 # ---------------------------------------------------------------------------
 # SPDX-License-Identifier: MIT
 # ---------------------------------------------------------------------------
@@ -26,8 +26,19 @@ MTDA_APT_URI ??= "https://apt.fury.io/mtda/"
 DEPENDS += "mtda-packages"
 do_build[deptask] += "do_deploy_deb"
 
-# Custom u-boot for the nanopi-r1
+# We suffix u-boot-script with DISTRO and MACHINE, remove the non-suffixed
+# version of the package
+IMAGE_INSTALL_remove = "u-boot-script"
+
+# Custom u-boot script for the beaglebone-black
+IMAGE_INSTALL_append_beaglebone-black = " u-boot-script-${DISTRO}-${MACHINE}"
+
+# Custom u-boot script for the nanopi-neo
+IMAGE_INSTALL_append_nanopi-neo = " u-boot-script-${DISTRO}-${MACHINE}"
+
+# Custom u-boot and script for the nanopi-r1
 DEPENDS_append_nanopi-r1 = " u-boot-nanopi-r1"
+IMAGE_INSTALL_append_nanopi-r1 = " u-boot-script-${DISTRO}-${MACHINE}"
 
 IMAGE_INSTALL += "                       \
     mtda-hostname                        \


### PR DESCRIPTION
u-boot-script ships /etc/default/u-boot-script where some machine
specific settings are placed (such as the kernel command line).
Add DISTRO and MACHINE to the name of the package to get separate
binary packages for the machines we support in our package feeds.

Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>