### PR TITLE
console/logger: Open console unconditionally

### DIFF
--- a/mtda/console/logger.py
+++ b/mtda/console/logger.py
@@ -303,8 +303,9 @@ class ConsoleLogger:
 
         if self.power_controller is not None:
             self.power_controller.wait()
-            with self.rx_lock:
-                con.open()
+
+        with self.rx_lock:
+            con.open()
 
         while self.rx_alive is True:
             if self.power_controller is not None:


### PR DESCRIPTION
The there is no power controller, assume that the device is already
powered. Without this, the console does not work in most cases.

Keeping the suspicious locking pattern untouched for now, that one is
likely broken as well.

Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>