### PR TITLE
meta-isar/recipes-python: Build local version

### DIFF
--- a/meta-isar/recipes-python/mtda/mtda_git.bb
+++ b/meta-isar/recipes-python/mtda/mtda_git.bb
@@ -7,8 +7,37 @@
 
 inherit dpkg
 
-SRC_URI += "git://git@github.com/siemens/mtda.git;protocol=https;branch=master"
-SRCREV   = "${AUTOREV}"
-S        = "${WORKDIR}/git"
+MTDA_FILES = " \
+    CONTRIBUTING.md \
+    COPYING \
+    LICENSES/ \
+    MAINTAINERS.md \
+    README.md \
+    configs/ \
+    debian/ \
+    docs/ \
+    mtda-cli \
+    mtda-ui \
+    mtda.ini \
+    mtda/ \
+    scripts/ \
+    setup.py \
+    tests/ \
+    tox.ini \
+    "
+
+SRC_URI += "${@' '.join(['file://' + d.getVar('LAYERDIR_mtda') + '/../' + file for file in d.getVar('MTDA_FILES').split()])}"
+
+S = "${WORKDIR}/working-repo"
 
 DEPENDS += "zerorpc-python zstandard"
+
+do_gen_working_repo() {
+	for file in ${MTDA_FILES}; do
+		cp -a ${LAYERDIR_mtda}/../$file ${S}/
+	done
+	rm -f ${S}/debian/source/format
+}
+do_gen_working_repo[cleandirs] += "${S}"
+
+addtask gen_working_repo after do_fetch before do_unpack


### PR DESCRIPTION
This avoids pulling random versions from github, permitting to package
local changes as well as clearly defined releases. The price is the need
of maintaining a list of top-level files and directories.

As the resulting input for the package build is now a local folder, the
source/format used for the Isar build needs to be switched to default.

Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>