### PR TITLE
power: Add shellcmd driver

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -80,7 +80,7 @@ General settings
 
   * ``variant``: string [required]
       Select a power variant from ``aviosys_8800``, ``gpio``, ``pduclient``, 
-      ``qemu`` and ``usbrelay``.
+      ``qemu``, ``shellcmd`` and ``usbrelay``.
 
 * ``remote``: section [optional]
     Specify the host and ports to connect to when using a MTDA client (such as
@@ -330,6 +330,22 @@ The following settings are supported:
 
 * ``watchdog``: string [optional]
     Name of the watchdog driver provided by QEMU/KVM for the selected machine.
+
+``shellcmd`` driver settings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``shellcmd`` driver may be used to control power switch with custom shell
+commands, e.g. curl requests:
+
+* ``on-cmd``: string [required]
+    Power-on shell command. The return code should be 1 on success.
+
+* ``off-cmd``: string [required]
+    Power-off shell command. The return code should be 1 on success.
+
+* ``check-on``: string [required]
+    Shell command to check the power state. Should return 0 if power is on, 1
+    if it is off. Any other return code is interpreted as error.
 
 ``usbrelay`` driver settings
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mtda/power/shellcmd.py
+++ b/mtda/power/shellcmd.py
@@ -1,0 +1,89 @@
+# ---------------------------------------------------------------------------
+# Shell command power driver for MTDA
+# ---------------------------------------------------------------------------
+#
+# This software is a part of MTDA.
+# Copyright (c) Siemens AG, 2022
+#
+# ---------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------
+
+# System imports
+import subprocess
+import threading
+
+# Local imports
+from mtda.power.controller import PowerController
+
+
+class ShellCmdPowerController(PowerController):
+
+    def __init__(self, mtda):
+        self.ev = threading.Event()
+        self.on_cmd = None
+        self.off_cmd = None
+        self.check_on = None
+        self.mtda = mtda
+
+    def configure(self, conf):
+        if 'on-cmd' in conf:
+            self.on_cmd = conf['on-cmd']
+        if 'off-cmd' in conf:
+            self.off_cmd = conf['off-cmd']
+        if 'check-on' in conf:
+            self.check_on = conf['check-on']
+
+    def probe(self):
+        if self.on_cmd is None:
+            raise ValueError("on-cmd not specified")
+        self.mtda.debug(3, "on-cmd: {}".format(self.on_cmd))
+        if self.off_cmd is None:
+            raise ValueError("off-cmd not specified")
+        self.mtda.debug(3, "off-cmd: {}".format(self.off_cmd))
+        if self.check_on is None:
+            raise ValueError("check-on not specified")
+        self.mtda.debug(3, "check_on: {}".format(self.check_on))
+
+    def command(self, args):
+        return False
+
+    def on(self):
+        proc = subprocess.run(self.on_cmd, shell=True, capture_output=True)
+        if proc.returncode != 0:
+            return False
+        self.ev.set()
+        return True
+
+    def off(self):
+        proc = subprocess.run(self.off_cmd, shell=True, capture_output=True)
+        if proc.returncode != 0:
+            return False
+        self.ev.clear()
+        return True
+
+    def status(self):
+        proc = subprocess.run(self.check_on, shell=True, capture_output=True)
+        self.mtda.debug(3, "check_on: {}".format(proc.returncode))
+        if proc.returncode == 0:
+            return self.POWER_ON
+        elif proc.returncode == 1:
+            return self.POWER_OFF
+        else:
+            self.POWER_UNSURE
+
+    def toggle(self):
+        s = self.status()
+        if s == self.POWER_OFF:
+            self.on()
+        else:
+            self.off()
+        return self.status()
+
+    def wait(self):
+        while self.status() != self.POWER_ON:
+            self.ev.wait()
+
+
+def instantiate(mtda):
+    return ShellCmdPowerController(mtda)


### PR DESCRIPTION
This driver allows to manage power switches via simple shell commands.
It is a break-out box for a broad range of bindings, e.g. by using curl
to talk to the REST interface of a power control.

Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>