### PR TITLE
storage/usbf: Remove and re-install storage when switching between host and target

### DIFF
--- a/mtda/storage/usbf.py
+++ b/mtda/storage/usbf.py
@@ -94,6 +94,8 @@ class UsbFunctionController(Image):
         self.mtda.debug(3, "storage.usbf.to_host()")
         self.lock.acquire()
 
+        Composite.remove()
+
         self.mode = self.SD_ON_HOST
         result = True
 
@@ -112,6 +114,13 @@ class UsbFunctionController(Image):
 
         if result is True:
             self.mode = self.SD_ON_TARGET
+
+        if self.file is not None:
+            if os.path.exists(self.file) is True:
+                result = Composite.install()
+            else:
+                self.mtda.debug(1, "storage.usbf.to_target(): "
+                                   "{} not found!".format(self.file))
 
         self.lock.release()
         self.mtda.debug(3, "storage.usbf.to_target(): {}".format(result))


### PR DESCRIPTION
This allows to replace the backing file while it is in host mode and
informs the USB gadget about changes to it. Also, the target will not be
able to access it anymore while it is in host mode.

Maybe it is possible to further automate updates by unconditionally reinstalling the device on target power-on.