### PR TITLE
setup: require pyzmq<23.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ and testers to remotely access and control hardware devices.
         "pyserial>=2.6",
         "python-daemon>=2.0",
         "pyusb>=1.0",
-        "pyzmq>=15.0",
+        "pyzmq>=15.0,<23.0.0",
         "psutil",
         "requests",
         "zerorpc>=0.6.0",


### PR DESCRIPTION
zerorpc fails with errors such as 'zerorpc.gevent_zmq' has no attribute
'PUSH' when running against the latest version. Changes to zerorpc are
probably required.

Closes: #242
Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>