### PR TITLE
meta-isar/recipes-python: make zerorpc-python work with pyzmq 23.0.0

### DIFF
--- a/meta-isar/recipes-python/zerorpc/files/0001-gevent_zmq-import-enums-from-pyzmq-23.0.0.patch
+++ b/meta-isar/recipes-python/zerorpc/files/0001-gevent_zmq-import-enums-from-pyzmq-23.0.0.patch
@@ -1,0 +1,41 @@
+License and copyright for files modified by this patch:
+
+SPDX-License-Identifier: MIT
+Copyright (c) 2015 François-Xavier Bourlet (bombela+zerorpc@gmail.com)
+
+From dd6843c114e9bfd6e81abf68f6a2eb3c598d1c2f Mon Sep 17 00:00:00 2001
+From: Cedric Hombourger <cedric.hombourger@siemens.com>
+Date: Thu, 19 May 2022 22:54:27 +0200
+Subject: [PATCH] gevent_zmq: import enums from pyzmq >= 23.0.0
+
+With pyzmq 23.0.0, constants were changed to enums and moved to the
+constants module. Attempt to import all globals from it into our zmq
+wrapper.
+
+Closes: #251
+Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>
+---
+ zerorpc/gevent_zmq.py | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/zerorpc/gevent_zmq.py b/zerorpc/gevent_zmq.py
+index 9430695..54420ae 100644
+--- a/zerorpc/gevent_zmq.py
++++ b/zerorpc/gevent_zmq.py
+@@ -27,6 +27,13 @@
+ # We want to act like zmq
+ from zmq import *  # noqa
+ 
++try:
++    # Try to import enums for pyzmq >= 23.0.0
++    from zmq.constants import *  # noqa
++except ImportError:
++    pass
++
++
+ # Explicit import to please flake8
+ from zmq import ZMQError
+ 
+-- 
+2.30.2
+

--- a/meta-isar/recipes-python/zerorpc/files/zerorpc-0.6.3/debian/changelog
+++ b/meta-isar/recipes-python/zerorpc/files/zerorpc-0.6.3/debian/changelog
@@ -1,3 +1,9 @@
+zerorpc-python (0.6.3-5) testing; urgency=low
+
+  * Pull fix submitted upstream for zerorpc to work with pyzmq 23.0.0 (issue #251)
+
+ -- Cedric Hombourger <cedric.hombourger@siemens.com>  Fri, 20 May 2022 15:30:00 +0100
+
 zerorpc-python (0.6.3-4) testing; urgency=low
 
   * Build-Depends against python3-all-dev

--- a/meta-isar/recipes-python/zerorpc/zerorpc-python_0.6.3.bb
+++ b/meta-isar/recipes-python/zerorpc/zerorpc-python_0.6.3.bb
@@ -9,8 +9,10 @@ inherit dpkg
 
 SRC_URI = " \
     https://files.pythonhosted.org/packages/73/ff/d61ef9f5d10e671421d1368e87d3525325483ebd7da262b1d3087443662b/zerorpc-${PV}.tar.gz \
+    file://0001-gevent_zmq-import-enums-from-pyzmq-23.0.0.patch \
     file://zerorpc-${PV}/debian \
 "
 
+PR = "5"
 S = "${WORKDIR}/zerorpc-${PV}"
 SRC_URI[sha256sum] = "d2ee247a566fc703f29c277d767f6f61f1e12f76d0402faea4bd815f32cbf37f"


### PR DESCRIPTION
Pull zerorpc-python submitted upstream (see issue #251) for 0.6.3 to
be compatible with pyzmq 23.0.0

Fixes: #242
Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>