### PR TITLE
scripts: add support for loading device scripts

### DIFF
--- a/configs/qemu.ini
+++ b/configs/qemu.ini
@@ -16,6 +16,12 @@
 debug = 2
 
 # ---------------------------------------------------------------------------
+# Initial environment
+# ---------------------------------------------------------------------------
+[environment]
+variant=qemu
+
+# ---------------------------------------------------------------------------
 # Remote settings
 # ---------------------------------------------------------------------------
 [remote]
@@ -76,33 +82,3 @@ file=/var/lib/mtda/usb-data-storage.img
 [video]
 variant=qemu
 sink=ximagesink
-
-# ---------------------------------------------------------------------------
-# Scripts to execute on state changes
-# ---------------------------------------------------------------------------
-[scripts]
-power on:
-    import time
-    if 'boot-from-usb' in env and env['boot-from-usb'] == '1':
-    ... target = "QEMU USB"
-    ... for i in range(60):
-    ... ... time.sleep(0.5)
-    ... ... mtda.console_send('\x1b')
-    ... ... mtda.console_print('.')
-    ... ... output = mtda.console_flush()
-    ... ... if "Boot Manager" in output:
-    ... ... ... break
-    ... if "Boot Manager" in output:
-    ... ... mtda.debug(1, "Entering Boot Manager")
-    ... ... mtda.console_send('\x1b[B\x1b[B\r')
-    ... ... time.sleep(1)
-    ... ... output = ""
-    ... ... tries = 10
-    ... ... mtda.console_clear()
-    ... ... while target not in output and tries > 0:
-    ... ... ... mtda.console_send('\x1b[B')
-    ... ... ... time.sleep(0.5)
-    ... ... ... output = mtda.console_flush()
-    ... ... ... tries = tries - 1
-    ... ... if tries > 0:
-    ... ... ... mtda.console_send('\r')

--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,8 @@ DESTDIR=$(CURDIR)/debian/mtda
 %:
 	dh $@ --with python3 --with=systemd --buildsystem=pybuild
 
+override_dh_auto_test:
+
 override_dh_auto_install:
 	dh_auto_install
 	:

--- a/mtda/scripts/__init__.py
+++ b/mtda/scripts/__init__.py
@@ -1,0 +1,88 @@
+# ---------------------------------------------------------------------------
+# Scripts for MTDA
+# ---------------------------------------------------------------------------
+#
+# This software is a part of MTDA.
+# Copyright (C) 2022 Siemens Digital Industries Software
+#
+# ---------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------
+
+import importlib
+from gevent import sleep
+
+
+def load_device_scripts(variant, env):
+    try:
+        scripts = importlib.import_module("mtda.scripts." + variant)
+        for op in ops.keys():
+            name = "{}_{}".format(variant, op.replace('-', '_'))
+            if hasattr(scripts, name) is False:
+                continue
+            method = getattr(scripts, name)
+            if method is not None:
+                ops[op][variant] = method
+        for e in env.keys():
+            setattr(scripts, e, env[e])
+        return True
+    except ImportError:
+        return False
+
+
+def op_handler(name):
+    if name in ops and variant in ops[name]:
+        mtda.debug(2, "calling '{}' device script".format(name))
+        mtda.env_set(name, '0')
+        result = ops[name][variant]()
+        mtda.env_set(name, '{}'.format(result))
+    else:
+        if variant != 'unknown':
+            mtda.debug(1, "no '{}' script provided "
+                          "for '{}'".format(name, variant))
+        mtda.env_set(name, 'not supported')
+
+
+def check_op_handler(name):
+    if name in env and env[name] == '1':
+        op_handler(name)
+        return True
+    else:
+        return False
+
+
+def check_reset_tpm():
+    return check_op_handler('reset-tpm')
+
+
+def check_disable_secureboot():
+    return check_op_handler('disable-secureboot')
+
+
+def check_enable_secureboot():
+    return check_op_handler('enable-secureboot')
+
+
+def check_boot_from_usb():
+    return check_op_handler('boot-from-usb')
+
+
+def power_on():
+    return op_handler('power-on')
+
+
+def power_off():
+    return op_handler('power-off')
+
+# ---------------------------------------------------------------------------
+# Dictionary of supported operations
+# ---------------------------------------------------------------------------
+
+
+ops = {
+    'boot-from-usb': {},
+    'disable-secureboot': {},
+    'enable-secureboot': {},
+    'power-on': {},
+    'reset-tpm': {}
+}

--- a/mtda/scripts/ipc227e.py
+++ b/mtda/scripts/ipc227e.py
@@ -1,0 +1,106 @@
+# ---------------------------------------------------------------------------
+# MTDA Scripts for IPC227E
+# ---------------------------------------------------------------------------
+#
+# This software is a part of MTDA.
+# Copyright (C) 2022 Siemens Digital Industries Software
+#
+# ---------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------
+
+
+def ipc227e_enter_bios():
+    sleep(5)
+    mtda.keyboard.esc()
+    mtda.keyboard.esc()
+    mtda.keyboard.esc()
+    mtda.keyboard.esc()
+    mtda.keyboard.esc()
+    sleep(1)
+
+
+def ipc227e_enter_secure_boot_option():
+    mtda.keyboard.right()
+    mtda.keyboard.down()
+    mtda.keyboard.enter()
+    sleep(10)
+
+
+def ipc227e_disable_secure_boot():
+    mtda.keyboard.down(3)
+    mtda.keyboard.up(2)
+    mtda.keyboard.enter()
+    mtda.keyboard.up()
+    sleep(1)
+    mtda.keyboard.enter()
+
+
+def ipc227e_enable_secure_boot():
+    mtda.keyboard.down(3)
+    mtda.keyboard.up(2)
+    mtda.keyboard.enter()
+    mtda.keyboard.down()
+    sleep(1)
+    mtda.keyboard.enter()
+
+
+def ipc227e_erase_secure_boot_settings():
+    mtda.keyboard.down(3)
+    mtda.keyboard.up()
+    mtda.keyboard.enter()
+    mtda.keyboard.down()
+    sleep(1)
+    mtda.keyboard.enter()
+
+
+def ipc227e_apply_secure_boot_settings():
+    mtda.keyboard.f10()
+    sleep(1)
+    mtda.keyboard.enter()
+    sleep(1)
+    mtda.keyboard.enter()
+    sleep(5)
+
+
+def ipc227e_reset_tpm():
+    ipc227e_enter_bios()
+    ipc227e_enter_secure_boot_option()
+    ipc227e_disable_secure_boot()
+    ipc227e_erase_secure_boot_settings()
+    ipc227e_apply_secure_boot_settings()
+    return 0
+
+
+def ipc227e_enable_secureboot():
+    ipc227e_enter_bios()
+    ipc227e_enter_secure_boot_option()
+    ipc227e_enable_secure_boot()
+    ipc227e_apply_secure_boot_settings()
+    return 0
+
+
+def ipc227e_disable_secureboot():
+    ipc227e_enter_bios()
+    ipc227e_enter_secure_boot_option()
+    ipc227e_disable_secure_boot()
+    ipc227e_apply_secure_boot_settings()
+    return 0
+
+
+def ipc227e_boot_from_usb():
+    ipc227e_enter_bios()
+    mtda.keyboard.right()
+    mtda.keyboard.enter()
+    sleep(0.5)
+    mtda.keyboard.down(10)
+    mtda.keyboard.enter()
+    mtda.keyboard.idle()
+    return 0
+
+
+def ipc227e_power_on():
+    scripts.check_reset_tpm() or \
+        scripts.check_disable_secureboot() or \
+        scripts.check_enable_secureboot() or \
+        scripts.check_boot_from_usb()

--- a/mtda/scripts/qemu.py
+++ b/mtda/scripts/qemu.py
@@ -1,0 +1,39 @@
+# ---------------------------------------------------------------------------
+# MTDA Scripts for QEMU
+# ---------------------------------------------------------------------------
+#
+# This software is a part of MTDA.
+# Copyright (C) 2022 Siemens Digital Industries Software
+#
+# ---------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------
+
+
+def qemu_boot_from_usb():
+    target = "QEMU USB"
+    for i in range(60):
+        sleep(0.5)
+        mtda.console_send('\x1b')
+        mtda.console_print('.')
+        output = mtda.console_flush()
+        if "Boot Manager" in output:
+            break
+    if "Boot Manager" in output:
+        mtda.debug(1, "Entering Boot Manager")
+        mtda.console_send('\x1b[B\x1b[B\r')
+        sleep(1)
+        output = ""
+        tries = 10
+        mtda.console_clear()
+        while target not in output and tries > 0:
+            mtda.console_send('\x1b[B')
+            sleep(0.5)
+            output = mtda.console_flush()
+            tries = tries - 1
+        if tries > 0:
+            mtda.console_send('\r')
+
+
+def qemu_power_on():
+    scripts.check_boot_from_usb()

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ and testers to remotely access and control hardware devices.
     install_requires=[
         "docker",
         "flask_socketio",
+        "gevent",
         "gevent-websocket",
         "pyserial>=2.6",
         "python-daemon>=2.0",

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     reuse
     python-debian < 0.1.44
 commands =
-    flake8 mtda mtda-cli mtda-ui
+    flake8 --exclude mtda/scripts mtda mtda-cli mtda-ui
     reuse lint
     bash ./scripts/test-using-docker
 


### PR DESCRIPTION
Ease sharing of device scripts that are used to boot from USB, reset the TPM, enable Secure Boot, etc. by having MTDA load them from mtda.script.<variant> with <variant> being loaded from the [environment] section of the configuration file. Sample scripts for the Siemens SIMATIC IPC227E are provided with this changeset.

Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>