### PR TITLE
meta-isar: images: add GPG key to the apt keyring

### DIFF
--- a/meta-isar/conf/layer.conf
+++ b/meta-isar/conf/layer.conf
@@ -1,9 +1,11 @@
 # ---------------------------------------------------------------------------
 # This Isar layer is part of MTDA
-# Copyright (C) 2021 Siemens Digital Industries Software
+# Copyright (C) 2023 Siemens Digital Industrial Software
 # ---------------------------------------------------------------------------
 # SPDX-License-Identifier: MIT
 # ---------------------------------------------------------------------------
+
+MTDA_LAYER := "${LAYERDIR}"
 
 BBPATH .= ":${LAYERDIR}"
 BBFILES += "                           \
@@ -18,3 +20,5 @@ BBFILE_PRIORITY_mtda = "10"
 LAYERVERSION_mtda = "1"
 LAYERSERIES_COMPAT_mtda = "v0.6"
 LAYERDIR_mtda = "${LAYERDIR}"
+
+THIRD_PARTY_APT_KEYS_append = " https://apt.fury.io/mtda/gpg.key;md5sum=bbdc764e1a3028aa70b6735692367f16"

--- a/meta-isar/recipes-core/images/mtda-image.bb
+++ b/meta-isar/recipes-core/images/mtda-image.bb
@@ -96,6 +96,6 @@ USERS_remove  = "isar"
 # Add mtda package feeds to /etc/apt/sources.list.d/
 ROOTFS_POSTPROCESS_COMMAND += "mtda_add_apt_sources"
 mtda_add_apt_sources() {
-    echo "deb [trusted=yes] ${MTDA_APT_URI} /" \
+    echo "deb ${MTDA_APT_URI} * *" \
         | sudo tee -a ${IMAGE_ROOTFS}/etc/apt/sources.list.d/mtda.list
 }


### PR DESCRIPTION
Gemfury now supports signed apt repositories, add the project GPG key to the 3rd-party keyring and remove [trusted=yes] from mtda.list

Signed-off-by: Cedric Hombourger <cedric.hombourger@siemens.com>