### PR TITLE
docs/build: remove .img from ISAR image name

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -237,7 +237,7 @@ pre-installed::
 Insert a microSD card to your system and write the generated image::
 
     # Check the microSD card device, /dev/mmcblk0 is used as an example
-    $ sudo dd if=build/tmp/deploy/images/nanopi-r1/isar-*.wic.img \
+    $ sudo dd if=build/tmp/deploy/images/nanopi-r1/isar-*.wic \
       of=/dev/mmcblk0 bs=8M
 
 (replace ``/dev/mmcblk0`` with the actual SD card device on your system).
@@ -358,7 +358,7 @@ pre-installed::
 Insert a microSD card to your system and write the generated image::
 
     # Check the microSD card device, /dev/mmcblk0 is used as an example
-    $ sudo dd if=build/tmp/deploy/images/nanopi-neo/isar-*.wic.img \
+    $ sudo dd if=build/tmp/deploy/images/nanopi-neo/isar-*.wic \
       of=/dev/mmcblk0 bs=8M
 
 (replace ``/dev/mmcblk0`` with the actual SD card device on your system).


### PR DESCRIPTION
ISAR generates an image without .img extension.