### PR TITLE
docs/build: power configuration example adapted to libgpiod

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -442,7 +442,7 @@ Hit ``i`` to enter the input mode and type the following configuration::
 
     [power]
     variant=gpio
-    pins=203
+    gpio=gpiochip0@203
 
     [keyboard]
     variant=hid
@@ -488,7 +488,7 @@ The following configuration file may be used for the DE0-Nano-SoC::
 
     [power]
     variant=gpio
-    pins=203
+    gpio=gpiochip0@203
 
     [storage]
     variant=samsung


### PR DESCRIPTION
Fix of the example configuration documentation for the NanoPi, which isn't adopted to the libgpiod style yet.