### PR TITLE
mtda: use tell() to report how many writes were completed

### DIFF
--- a/mtda/storage/controller.py
+++ b/mtda/storage/controller.py
@@ -62,6 +62,11 @@ class StorageController(object):
         return CONSTS.STORAGE.UNKNOWN
 
     @abc.abstractmethod
+    def tell(self):
+        """ Return position within the storage"""
+        return None
+
+    @abc.abstractmethod
     def update(self, dst, offset):
         """ Update specified file"""
         return False

--- a/mtda/storage/helpers/image.py
+++ b/mtda/storage/helpers/image.py
@@ -272,6 +272,18 @@ class Image(StorageController):
     def supports_hotplug(self):
         return False
 
+    def tell(self):
+        self.mtda.debug(3, "storage.helpers.image.tell()")
+        self.lock.acquire()
+
+        result = None
+        if self.handle is not None:
+            result = self.handle.tell()
+
+        self.mtda.debug(3, "storage.helpers.image.tell(): %s" % str(result))
+        self.lock.release()
+        return result
+
     def _locate(self, dst):
         self.mtda.debug(3, "storage.helpers.image._locate()")
 


### PR DESCRIPTION
Some decompressors may perform writes in the background and/or after the final call to write(). Add tell() to the storage interface to report the current position within the storage instead of calculating it from the some of return values from write(). This fixes the issue of no progress being shown after a zst stream was consumed.