### PR TITLE
improve caching of mtda isar layer

### DIFF
--- a/meta-isar/conf/layer.conf
+++ b/meta-isar/conf/layer.conf
@@ -20,5 +20,6 @@ BBFILE_PRIORITY_mtda = "10"
 LAYERVERSION_mtda = "1"
 LAYERSERIES_COMPAT_mtda = "v0.6"
 LAYERDIR_mtda = "${LAYERDIR}"
+LAYERDIR_mtda[vardepvalue] = "mtda"
 
 THIRD_PARTY_APT_KEYS:append = " https://apt.fury.io/mtda/gpg.key;md5sum=bbdc764e1a3028aa70b6735692367f16"


### PR DESCRIPTION
The layerdir variable contains an absolute path that is immediately expanded and points into the build host. This breaks sstate caching for tasks that reference this variable when building from a different path (like in the gitlab-ci). To fix this, we simply set the vardepvalue to a fixed value. As this variable just points to the current layer, there are no logical external changes expected and by that, this "pinning" is fine.