### PR TITLE
Add support to run MTDA web frontend behind reverse proxy

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -155,3 +155,6 @@ Files: mtda/assets/xterm.js
 Copyright: 2014 The xterm.js authors.
 License: MIT
 
+Files: mtda/share/nginx-multi-mtda.conf
+Copyright: 2023 Siemens AG
+License: MIT

--- a/mtda/assets/material_icons.css
+++ b/mtda/assets/material_icons.css
@@ -2,7 +2,7 @@
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: url(./assets/material_icons.ttf) format('truetype');
+  src: url(./material_icons.ttf) format('truetype');
 }
 
 .material-icons {

--- a/mtda/assets/vnc.js
+++ b/mtda/assets/vnc.js
@@ -9,8 +9,8 @@
 // SPDX-License-Identifier: MIT
 // --------------------------------------------------------------------------
 
-import * as WebUtil from '/novnc/app/webutil.js';
-import RFB from '/novnc/core/rfb.js';
+import * as WebUtil from '../novnc/app/webutil.js';
+import RFB from '../novnc/core/rfb.js';
 
 var rfb;
 var desktopName;

--- a/mtda/share/nginx-multi-mtda.conf
+++ b/mtda/share/nginx-multi-mtda.conf
@@ -1,0 +1,33 @@
+# This software is a part of MTDA.
+# Copyright (C) 2023 Siemens AG
+#
+# This example provides a nginx site config to access
+# one or more MTDA devices via a single web frontend
+# The devices can be accessed using <host>/device/<ip>/
+
+server {
+    listen 80;
+    listen [::]:80;
+
+    location / {
+        proxy_pass http://mtda-web;
+    }
+
+    # to restrict access to the MTDA devices, fine-tune this rule
+    location ~* ^/device/(?<phost>[\d.]+)(?<puri>/.*) {
+        set $adr http://$phost;
+        rewrite .* $puri break;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $host;
+        proxy_pass $adr;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+
+upstream mtda-web {
+    server unix:/run/testbed-webserver/http.sock;
+}

--- a/mtda/templates/index.html
+++ b/mtda/templates/index.html
@@ -108,7 +108,7 @@ SPDX-License-Identifier: MIT
     <script type=text/javascript>
       $(function() {
         $('a#power-toggle').bind('click', function() {
-          $.getJSON('/power-toggle', function(data) {
+          $.getJSON('./power-toggle', function(data) {
             // do nothing
           });
           return false;
@@ -118,7 +118,7 @@ SPDX-License-Identifier: MIT
         $('a#keyboard-show').bind('click', function() {
           Keyboard.open('', function(data) {
             console.log("#### <KEY> " + data);
-            $.getJSON('/keyboard-input', {input: data}, function(data) {
+            $.getJSON('./keyboard-input', {input: data}, function(data) {
               // do nothing
             });
           }, '');
@@ -141,7 +141,7 @@ SPDX-License-Identifier: MIT
         socket.emit("console-input", { input: data });
       });
 
-      const socket = io.connect("/mtda");
+      const socket = io.connect("/mtda", {path: window.location.pathname + "socket.io/"});
       const status = document.getElementById("mtda_status");
       const version = document.getElementById("mtda_version");
       const video = document.getElementById("video");


### PR DESCRIPTION
This change ensures that all resources are references relative to the
current URI. By that, the whole MTDA web frontend can be served below a
subpath. This is required to support use-cases where multiple MTDA
devices are served by a single nginx reverse proxy in a single web page.
This approach can be used to serve a whole testing network via a single
IP entrypoint and without giving the users IP access to the testing
network itself.

To make the socket.io communication work, we further set the path
component of the current URI when connecting to the ws server.