### PR TITLE
Add mtda-www to image and fix web-ui console for bookworm

### DIFF
--- a/meta-isar/recipes-core/images/mtda-image.bb
+++ b/meta-isar/recipes-core/images/mtda-image.bb
@@ -46,6 +46,7 @@ IMAGE_PREINSTALL += "                    \
     isc-dhcp-client                      \
     mjpg-streamer                        \
     mtda                                 \
+    mtda-www                             \
     network-manager                      \
     pdudaemon-client                     \
     sd-mux-ctrl                          \

--- a/mtda/assets/vnc.js
+++ b/mtda/assets/vnc.js
@@ -35,7 +35,7 @@ function disconnected(e) {
     }
 }
 
-WebUtil.init_logging(WebUtil.getConfigVar('logging', 'warn'));
+WebUtil.initLogging(WebUtil.getConfigVar('logging', 'warn'));
 var host = WebUtil.getConfigVar('host', window.location.hostname);
 var port = 5901
 var password = ''

--- a/mtda/templates/index.html
+++ b/mtda/templates/index.html
@@ -10,19 +10,7 @@ SPDX-License-Identifier: MIT
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <link rel="stylesheet" href="./assets/material_icons.css">
     <link rel="stylesheet" href="./assets/keyboard.css">
-    <link rel="stylesheet" href="novnc/app/styles/lite.css">
-    <script src="novnc/vendor/promise.js"></script>
-    <script type="module">
-        window._noVNC_has_module_support = true;
-    </script>
-    <script>
-        window.addEventListener("load", function() {
-            if (window._noVNC_has_module_support) return;
-            var loader = document.createElement("script");
-            loader.src = "novnc/vendor/browser-es-module-loader/dist/browser-es-module-loader.js";
-            document.head.appendChild(loader);
-        });
-    </script>
+    <link rel="stylesheet" href="novnc/app/styles/base.css">
     <script type="module" crossorigin="anonymous" src="./assets/vnc.js"></script>
     <title>Multi-Tenant Device Access</title>
     <link rel="stylesheet" href="./assets/xterm.css"/>


### PR DESCRIPTION

Firstly the mtda-www package is added to the image. This is done because installing it manually afterwards with `sudo apt install mtda-www` from the fury repository installs it for python 3.9. and not the 3.11. version for bookworm.
Also, since the choice of using the webview comes from the configuration files anyway, it should not interfere.

Secondly, referring to #300, the `mtda/templates/index.html` and `mtda/assets/vnc.js` was changed to work with the newer novnc-package which is used in debian bookworm(https://packages.debian.org/bookworm/all/novnc/filelist). 

Consider that this will break the web-view for all mtda-images which are still built with bullseye. 
 