### PR TITLE
feat: auto-detect serial interface of sdwire

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -386,8 +386,8 @@ a SD card between the DUT and host. The following settings are supported:
   ``/dev/sda``)
 
 * ``serial``: string [optional]
-  Identifier of the sdmux/sdwire device to use (defaults to ``sdmux``). Use
-  ``sd-mux-ctrl`` to list available devices.
+  Identifier of the sdmux/sdwire device to use. Use ``sd-mux-ctrl`` to list
+  available devices. When not specified, the first device is auto-detected.
 
 ``usbf`` driver settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mtda/storage/samsung.py
+++ b/mtda/storage/samsung.py
@@ -22,18 +22,26 @@ class SamsungSdMuxStorageController(Image):
     def __init__(self, mtda):
         super().__init__(mtda)
         self.file = "/dev/sda"
-        self.serial = "sdmux"
+        self.serial = None
 
     """ Configure this storage controller from the provided configuration"""
     def configure(self, conf):
         self.mtda.debug(3, "storage.samsung.configure()")
 
-        result = None
+        result = True
         if 'device' in conf:
             self.file = conf['device']
         if 'serial' in conf:
             self.serial = conf['serial']
-
+        else:
+            try:
+                self.serial = subprocess.check_output([
+                    "sd-mux-ctrl", "--device-id", "0", "--show-serial"
+                ])
+            except subprocess.CalledProcessError:
+                result = False
+        self.mtda.debug(2, "storage.samsung.configure(): serial: %s" %
+                        self.serial)
         self.mtda.debug(3, "storage.samsung.configure(): %s" % str(result))
         return result
 


### PR DESCRIPTION
The serial of the sdwire interface depends on the physical device it is attached to. This makes it impossible to pre-configure multiple MTDA devices for a mass deployment.

This patch auto-detects the serial of an sdwire in case it is not specified in the configuration. This simplifies the default configuration and also enables pre-configuration of MTDA devices.

Note: This has been tested on multiple nanopi-neo boards with sdwire interfaces.

cc @bovi 