### PR TITLE
mtda-service: do not die if ZeroConf fails to register the service

### DIFF
--- a/mtda-service
+++ b/mtda-service
@@ -87,14 +87,19 @@ class Application:
                 properties=props,
                 server='{}.local.'.format(name))
 
-        zc.register_service(info)
+        try:
+            zc.register_service(info)
+        except zeroconf.NonUniqueNameException:
+            info = None
+
         try:
             s.run()
         except KeyboardInterrupt:
             s.stop()
             self.agent.stop()
         finally:
-            zc.unregister_service(info)
+            if info is not None:
+                zc.unregister_service(info)
 
         return True
 


### PR DESCRIPTION
register_service() may raise NonUniqueNameException if a device with the same name (defaulting to the static hostname, i.e. /etc/hostname) is already on the network. Do not die if that happens and simply disable Zeroconf.

Fixes: #329