### PR TITLE
kas: update to the latest HEAD of the isar tree

### DIFF
--- a/kas/common/base.yml
+++ b/kas/common/base.yml
@@ -21,7 +21,7 @@ repos:
       meta-isar:
   isar:
     url: https://github.com/ilbers/isar.git
-    commit: 1f500d59b02c34549f96b5ece93cd99884ab52bb
+    commit: 61086915e6c83fff22effa85cda64a2ac0c2f100
     layers:
       meta:
       meta-isar:


### PR DESCRIPTION
The main (and only?) driver for this update is to remain up-to-date with the isar project.