### PR TITLE
feat(www): support mjpeg streamer via reverse proxy

### DIFF
--- a/mtda/share/nginx-multi-mtda.conf
+++ b/mtda/share/nginx-multi-mtda.conf
@@ -4,6 +4,9 @@
 # This example provides a nginx site config to access
 # one or more MTDA devices via a single web frontend
 # The devices can be accessed using <host>/device/<ip>/
+#
+# Note: We assume, that the mtda-www is running on
+# port 80 and the mjpeg streamer endpoint on port 8080
 
 server {
     listen 80;
@@ -16,6 +19,10 @@ server {
     # to restrict access to the MTDA devices, fine-tune this rule
     location ~* ^/device/(?<phost>[\d.]+)(?<puri>/.*) {
         set $adr http://$phost;
+        # mjpeg streamer endpoint
+        if ($request_uri ~ '\?action=stream') {
+            set $adr http://$phost:8080;
+        }
         rewrite .* $puri break;
         proxy_set_header X-Forwarded-Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/mtda/templates/index.html
+++ b/mtda/templates/index.html
@@ -147,7 +147,13 @@ SPDX-License-Identifier: MIT
           vnc_load()
         }
         else {
-          video.innerHTML = '<img src="' + info.url + '" />'
+          const selfpath = window.location.pathname
+          var url = info.url
+          // running behind a reverse proxy (assuming /device subpath)
+          if(selfpath.startsWith('/device')){
+            url = selfpath + url.match('(?:http|https)://.*?/(.*)')[1]
+          }
+          video.innerHTML = '<img src="' + url + '" />'
         }
       });
 


### PR DESCRIPTION
This patch adds support to also serve the mjpeg streamer endpoint via a reverse proxy. The reverse proxy is auto-detected based on a heuristic (access path starts with /device). The example nginx reverse proxy configuration is updated accordingly.

cc @bovi 