### PR TITLE
fix(video): avoid timeout during check for v4l2 device

### DIFF
--- a/mtda/video/mjpg_streamer.py
+++ b/mtda/video/mjpg_streamer.py
@@ -54,6 +54,9 @@ class MJPGStreamerVideoController(VideoController):
 
     def configure_systemd(self, dir):
         device = os.path.basename(self.dev)
+        # the device is already there and might not be managed by systemd
+        if os.path.exists(device):
+            return
         dropin = os.path.join(dir, 'auto-dep-video.conf')
         with open(dropin, 'w') as f:
             f.write('[Unit]\n')


### PR DESCRIPTION
At least on debian bookworm, the v4l2 devices are not managed by systemd (the udev rule does not add the systemd tag). By that, we cannot use systemd to wait for the device as this will always timeout. It is also not easily possible to check if a device is (or will be) managed by systemd. Hence, we simply check if the device is present. In this case, we do not add the systemd device dependency. In other cases, we add it as the device might be managed by systemd and show up later.

We also considered adding a udev rule to tag the devices, but this makes the mtda package less portable.

cc @bovi 