### PR TITLE
fix(client): clamp heartbeat to timeout value

### DIFF
--- a/mtda/client.py
+++ b/mtda/client.py
@@ -36,8 +36,9 @@ class Client:
         agent.load_config(host, config_files=config_files)
         if agent.remote is not None:
             uri = "tcp://%s:%d" % (agent.remote, agent.ctrlport)
-            self._impl = zerorpc.Client(heartbeat=CONSTS.RPC.HEARTBEAT,
-                                        timeout=timeout)
+            self._impl = zerorpc.Client(
+                heartbeat=min(timeout, CONSTS.RPC.HEARTBEAT),
+                timeout=timeout)
             self._impl.connect(uri)
         else:
             self._impl = agent


### PR DESCRIPTION
When using RPC timeouts shorter than the heartbeat value, the timeout of the RPC call was not properly working, as the call only returned after the heartbeat duration. In normal operation, this was not an issue, as the heartbeat was significantly shorter than the timeout, and also timeouts only happened due to function invocation timeouts, but not due to connectivity losses.

When working with one-shot RPCs (i.e. create a client to only call one rpc), this led to huge delays and an accumulation of half-open TCP connections. By clamping (limiting) the heartbeat duration to the timeout, also short timeouts are properly supported now.