### PR TITLE
fix(video): use udev rules to wait for the video device

### DIFF
--- a/debian/mtda.udev
+++ b/debian/mtda.udev
@@ -1,0 +1,2 @@
+KERNEL=="video*", TAG+="systemd"
+KERNEL=="video*", SUBSYSTEM=="video4linux", SUBSYSTEMS=="usb", SYMLINK="usb-video$attr{index}"


### PR DESCRIPTION
systemd does not manage video device on its own but may be told to via udev rules that add "systemd" to the device TAGS. In addition, we need to resolve the name of the device in /dev to a sysfs device and then systemd .device unit.