### PR TITLE
refactor(mtda): use upstream packages on bookworm

### DIFF
--- a/meta-isar/recipes-python/mtda/mtda_git.bb
+++ b/meta-isar/recipes-python/mtda/mtda_git.bb
@@ -36,6 +36,9 @@ SRC_URI += "${@' '.join(['file://' + d.getVar('LAYERDIR_mtda') + '/../' + file f
 S = "${WORKDIR}/working-repo"
 
 DEPENDS += "zerorpc-python kconfiglib py3qterm python-zstandard"
+# bookworm ships suitable versions of these packages
+DEPENDS:remove:bookworm = "python-zstandard"
+DEPENDS:remove:bookworm = "kconfiglib"
 
 do_gen_working_repo() {
 	for file in ${MTDA_FILES}; do


### PR DESCRIPTION
Some packages we currently build locally are already available in debian bookworm. By using these, we automatically get security updates and also reduce the build time of the mtda images. This reduces the build time of the debian bookworm images by more than 10 minutes.

cc @bovi 