### PR TITLE
Add support for streaming via ustreamer

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -143,8 +143,7 @@ General settings
     Device Under Test. The driver will be selected with ``variant``.
 
   * ``variant``: string [required]
-      Select a ``video`` variant: ``mjpg_streamer`` is the only supported
-      driver at this time.
+      Select a ``video`` variant: ``mjpg_streamer`` or ``ustreamer``
 
 * ``www``: section [optional]
    A lightweight web server will be started when this section is present.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -143,7 +143,7 @@ General settings
     Device Under Test. The driver will be selected with ``variant``.
 
   * ``variant``: string [required]
-      Select a ``video`` variant: ``mjpg_streamer`` or ``ustreamer``
+      Select a ``video`` variant: ``mjpg_streamer`` (deprecated) or ``ustreamer``
 
 * ``www``: section [optional]
    A lightweight web server will be started when this section is present.

--- a/meta-isar/recipes-core/images/mtda-image.bb
+++ b/meta-isar/recipes-core/images/mtda-image.bb
@@ -46,6 +46,7 @@ IMAGE_PREINSTALL += "                    \
     iproute2                             \
     isc-dhcp-client                      \
     mjpg-streamer                        \
+    ustreamer                            \
     mtda                                 \
     mtda-www                             \
     pdudaemon-client                     \

--- a/mtda.ini
+++ b/mtda.ini
@@ -209,7 +209,7 @@ variant=usbf
 # Video capture
 # ---------------------------------------------------------------------------
 # [video]
-# variant=mjpg_streamer
+# variant=ustreamer
 # device=/dev/video0
 # resolution=1280x780
 # port=8080

--- a/mtda/templates/index.html
+++ b/mtda/templates/index.html
@@ -154,6 +154,7 @@ SPDX-License-Identifier: MIT
             url = selfpath + url.match('(?:http|https)://.*?/(.*)')[1]
           }
           video.innerHTML = '<img src="' + url + '" />'
+          document.getElementById('vnc_status').innerHTML = '<span style="color: green;"><b>Video</b></span>';
         }
       });
 

--- a/mtda/video/mjpg_streamer.py
+++ b/mtda/video/mjpg_streamer.py
@@ -38,6 +38,8 @@ class MJPGStreamerVideoController(VideoController):
 
     def configure(self, conf):
         self.mtda.debug(3, "video.mjpg_streamer.configure()")
+        self.mtda.debug(2, "video.mjpg_streamer is deprecated. "
+                           "Use video.ustreamer instead")
 
         if 'device' in conf:
             self.dev = conf['device']

--- a/mtda/video/ustreamer.py
+++ b/mtda/video/ustreamer.py
@@ -1,0 +1,130 @@
+# ---------------------------------------------------------------------------
+# ustreamer driver for MTDA
+# ---------------------------------------------------------------------------
+#
+# This software is a part of MTDA.
+# Copyright (C) 2023 Siemens AG
+#
+# ---------------------------------------------------------------------------
+# SPDX-License-Identifier: MIT
+# ---------------------------------------------------------------------------
+
+# System imports
+import os
+import socket
+import threading
+import signal
+import subprocess
+
+# Local imports
+from mtda.video.controller import VideoController
+
+
+class UStreamerVideoController(VideoController):
+
+    def __init__(self, mtda):
+        self.dev = "/dev/video0"
+        self.executable = "ustreamer"
+        self.lock = threading.Lock()
+        self.mtda = mtda
+        self.worker = None
+        self.ustreamer = None
+        self.port = 8080
+        self.desired_fps = 30
+        self.resolution = "1280x780"
+        self.www = None
+
+    def configure(self, conf):
+        self.mtda.debug(3, "video.ustreamer.configure()")
+
+        if 'device' in conf:
+            self.dev = conf['device']
+            self.mtda.debug(4, 'video.ustreamer.configure(): '
+                               'will use %s' % str(self.dev))
+        if 'executable' in conf:
+            self.executable = conf['executable']
+        if 'port' in conf:
+            self.port = conf['port']
+        if 'resolution' in conf:
+            self.resolution = conf['resolution']
+        if 'www' in conf:
+            self.www = conf['www']
+
+    def configure_systemd(self, dir):
+        device = os.path.basename(self.dev)
+        dropin = os.path.join(dir, 'auto-dep-video.conf')
+        with open(dropin, 'w') as f:
+            f.write('[Unit]\n')
+            f.write('Wants=dev-{}.device\n'.format(device))
+            f.write('After=dev-{}.device\n'.format(device))
+
+    @property
+    def format(self):
+        return "MJPG"
+
+    def probe(self):
+        self.mtda.debug(3, 'video.ustreamer.probe()')
+
+        if self.executable is None:
+            raise ValueError('ustreamer executable not specified!')
+
+        result = True
+        try:
+            subprocess.check_call([self.executable, '--version'])
+        except subprocess.SubprocessError as e:
+            self.mtda.debug(1, 'error calling %s: %s', self.executable, str(e))
+            result = False
+
+        self.mtda.debug(3, 'video.ustreamer.probe(): %s' % str(result))
+        return result
+
+    def start(self):
+        self.mtda.debug(3, 'video.ustreamer.start()')
+
+        options = [
+            '-d', self.dev, '-r', self.resolution,
+            '-s', '0.0.0.0',
+            '-p', str(self.port),
+            '--drop-same-frames', '30',
+            '-c', 'HW',    # do not transcode frames (if supported)
+            '-f', str(self.desired_fps),
+            '--slowdown',  # capture with 1 fps when no client
+            ]
+        if self.www:
+            options += ['--static', self.www]
+
+        with self.lock:
+            self.ustreamer = subprocess.Popen([self.executable] + options)
+
+        return True
+
+    def stop(self):
+        self.mtda.debug(3, 'video.ustreamer.stop()')
+
+        with self.lock:
+            if self.ustreamer.poll() is None:
+                self.ustreamer.send_signal(signal.SIGINT)
+            try:
+                self.ustreamer.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.mtda.debug(2, 'video.ustreamer.stop: '
+                                   'process did not finish, killing')
+                self.ustreamer.kill()
+
+        return True
+
+    def url(self, host="", opts=None):
+        self.mtda.debug(3, "video.ustreamer.url(host='%s')" % str(host))
+
+        if host is None or host == "":
+            host = socket.getfqdn()
+            self.mtda.debug(3, "video.ustreamer.url: "
+                               "using host='%s'" % str(host))
+        result = "http://{0}:{1}/?action=stream".format(host, self.port)
+
+        self.mtda.debug(3, 'video.ustreamer.url(): %s' % str(result))
+        return result
+
+
+def instantiate(mtda):
+    return UStreamerVideoController(mtda)


### PR DESCRIPTION
For now, we support both mjpg_streamer and ustreamer, but the plan is to eventually deprecate mjpg_streamer. This has been successfully tested with some screen grabbers and cameras, but more testing should be done. Anyways, I'll already provide the patches so more folks can help with the review and testing.

It also uses a more "modern" approach to run the streamer in the background.

cc @bovi 