### PR TITLE
fix(video): avoid timeout during check for v4l2 device | v2

### DIFF
--- a/debian/mtda.udev
+++ b/debian/mtda.udev
@@ -1,0 +1,2 @@
+KERNEL=="video*", TAG+="systemd"
+KERNEL=="video*", SUBSYSTEM=="video4linux", SUBSYSTEMS=="usb", SYMLINK="usb-video$attr{index}"

--- a/mtda/console/serial.py
+++ b/mtda/console/serial.py
@@ -15,6 +15,7 @@ import serial
 
 # Local imports
 from mtda.console.interface import ConsoleInterface
+from mtda.utils import SystemdDeviceUnit
 
 
 class SerialConsole(ConsoleInterface):
@@ -43,12 +44,8 @@ class SerialConsole(ConsoleInterface):
 
         result = None
         if self.port is not None:
-            device = os.path.basename(self.port)
             dropin = os.path.join(dir, 'auto-dep-{}.conf'.format(self.role))
-            with open(dropin, 'w') as f:
-                f.write('[Unit]\n')
-                f.write('Wants=dev-{}.device\n'.format(device))
-                f.write('After=dev-{}.device\n'.format(device))
+            SystemdDeviceUnit.create_device_dependency(dropin, self.port)
 
         self.mtda.debug(3, "console.serial.configure_systemd(): "
                            "{}".format(result))

--- a/mtda/storage/usbf.py
+++ b/mtda/storage/usbf.py
@@ -17,6 +17,7 @@ import stat
 import mtda.constants as CONSTS
 from mtda.storage.helpers.image import Image
 from mtda.support.usb import Composite
+from mtda.utils import SystemdDeviceUnit
 
 
 class UsbFunctionController(Image):
@@ -59,12 +60,8 @@ class UsbFunctionController(Image):
         mode = os.stat(self.file).st_mode
         if stat.S_ISBLK(mode) is False:
             return
-        device = os.path.basename(self.file)
         dropin = os.path.join(dir, 'auto-dep-storage.conf')
-        with open(dropin, 'w') as f:
-            f.write('[Unit]\n')
-            f.write('Wants=dev-{}.device\n'.format(device))
-            f.write('After=dev-{}.device\n'.format(device))
+        SystemdDeviceUnit.create_device_dependency(dropin, self.file)
 
     """ Get file used by the USB Function driver"""
     def probe(self):

--- a/mtda/utils.py
+++ b/mtda/utils.py
@@ -16,3 +16,17 @@ class RepeatTimer(threading.Timer):
     def run(self):
         while not self.finished.wait(self.interval):
             self.function(*self.args, **self.kwargs)
+
+
+class SystemdDeviceUnit():
+    def create_device_dependency(dropin_path: str, device_path: str):
+        """
+        Create a systemd drop-in file to wait for a specific device
+        to become available.
+        """
+        # escape device name according to systemd.unit requirements
+        device = device_path[1:].replace('-', '\\x2d').replace('/', '-')
+        with open(dropin_path, 'w') as f:
+            f.write('[Unit]\n')
+            f.write('Wants={}.device\n'.format(device))
+            f.write('After={}.device\n'.format(device))

--- a/mtda/video/mjpg_streamer.py
+++ b/mtda/video/mjpg_streamer.py
@@ -20,6 +20,7 @@ import time
 
 # Local imports
 from mtda.video.controller import VideoController
+from mtda.utils import SystemdDeviceUnit
 
 
 class MJPGStreamerVideoController(VideoController):
@@ -55,12 +56,8 @@ class MJPGStreamerVideoController(VideoController):
             self.www = conf['www']
 
     def configure_systemd(self, dir):
-        device = os.path.basename(self.dev)
         dropin = os.path.join(dir, 'auto-dep-video.conf')
-        with open(dropin, 'w') as f:
-            f.write('[Unit]\n')
-            f.write('Wants=dev-{}.device\n'.format(device))
-            f.write('After=dev-{}.device\n'.format(device))
+        SystemdDeviceUnit.create_device_dependency(dropin, self.dev)
 
     @property
     def format(self):

--- a/mtda/video/ustreamer.py
+++ b/mtda/video/ustreamer.py
@@ -18,6 +18,7 @@ import subprocess
 
 # Local imports
 from mtda.video.controller import VideoController
+from mtda.utils import SystemdDeviceUnit
 
 
 class UStreamerVideoController(VideoController):
@@ -51,12 +52,8 @@ class UStreamerVideoController(VideoController):
             self.www = conf['www']
 
     def configure_systemd(self, dir):
-        device = os.path.basename(self.dev)
         dropin = os.path.join(dir, 'auto-dep-video.conf')
-        with open(dropin, 'w') as f:
-            f.write('[Unit]\n')
-            f.write('Wants=dev-{}.device\n'.format(device))
-            f.write('After=dev-{}.device\n'.format(device))
+        SystemdDeviceUnit.create_device_dependency(dropin, self.dev)
 
     @property
     def format(self):


### PR DESCRIPTION
This is another try at fixing the systemd unit dependency to the screen grabber. It is based on #349, but only uses the udev part. It has been tested on an nanopi-neo with a USB3 screen grabber attached.

cc @bovi 