### PR TITLE
ci: bump auto-assign-action and setup-python versions

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -19,4 +19,4 @@ jobs:
   add-reviews:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v1.2.1
+      - uses: kentaro-m/auto-assign-action@v1.2.5

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install pypa/build


### PR DESCRIPTION
Fixes ci job warning:
The following actions uses node12 which is deprecated and will be forced to run on node16

Auto assign release: https://github.com/kentaro-m/auto-assign-action/releases
Setup python release: https://github.com/actions/setup-python/releases