### PR TITLE
docs/install.rst: do GPG key setup before setting sources for debian

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,10 +4,19 @@ Installation
 Using apt on Debian 12
 ----------------------
 
+Set up MTDA apt repository::
+
+   # Add MTDA's GPG key:
+   $ sudo install -m 0755 -d /etc/apt/keyrings
+   $ curl -fsSL https://apt.fury.io/mtda/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/mtda.gpg
+   $ sudo chmod a+r /etc/apt/keyrings/mtda.gpg
+
+   # Add repository to Apt sources
+   $ echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/mtda.gpg] https://apt.fury.io/mtda/ /" | sudo tee /etc/apt/sources.list.d/mtda.list
+     deb [arch=amd64 signed-by=/etc/apt/keyrings/mtda.gpg] https://apt.fury.io/mtda/ /
+
 Packages for Debian 12 (bookworm) may be installed as follows::
 
-   $ echo 'deb [trusted=yes] https://apt.fury.io/mtda/ /' | \
-     sudo tee /etc/apt/sources.list.d/mtda.list
    $ sudo apt-get update
    $ sudo apt-get install -y mtda
 


### PR DESCRIPTION
Fixes GPG warning observed while performing 'apt update' operation:
GPG error: https://apt.fury.io/mtda  InRelease: The following signatures couldn't be verified because the public key is not available

Signed-off-by: Badrikesh Prusty <badrikesh.prusty@siemens.com>

Apt warning observed:
```
badrikesh@debian:~$ sudo apt update
Hit:1 http://deb.debian.org/debian bookworm InRelease
Hit:2 http://security.debian.org/debian-security bookworm-security InRelease
Hit:3 http://deb.debian.org/debian bookworm-updates InRelease
Hit:4 http://deb.debian.org/debian bookworm-backports InRelease
Get:5 https://apt.fury.io/mtda  InRelease [1,975 B]
Ign:5 https://apt.fury.io/mtda  InRelease
Get:6 https://apt.fury.io/mtda  Packages [228 kB]
Fetched 230 kB in 3s (87.6 kB/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
2 packages can be upgraded. Run 'apt list --upgradable' to see them.
W: GPG error: https://apt.fury.io/mtda  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY C8F9D89C247C0257
```

After adding gpg key:
```
badrikesh@debian:~$ ls -l /etc/apt/keyrings
total 4
-rw-r--r-- 1 root root 2265 Oct 23 03:45 mtda.gpg
badrikesh@debian:~$ cat /etc/apt/sources.list.d/mtda.list
deb [arch=amd64 signed-by=/etc/apt/keyrings/mtda.gpg] https://apt.fury.io/mtda/ /

badrikesh@debian:~$ sudo apt update
Hit:1 http://deb.debian.org/debian bookworm InRelease
Hit:2 http://security.debian.org/debian-security bookworm-security InRelease
Hit:3 http://deb.debian.org/debian bookworm-updates InRelease
Hit:4 http://deb.debian.org/debian bookworm-backports InRelease
Get:5 https://apt.fury.io/mtda  InRelease [1,975 B]
Fetched 1,975 B in 1s (1,446 B/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
2 packages can be upgraded. Run 'apt list --upgradable' to see them.
badrikesh@debian:~$
```