### PR TITLE
recipes-conf/mtda-repo: append source list with ' /' (vs ' * *')

### DIFF
--- a/meta-isar/recipes-conf/mtda-repo/files/postinst.tmpl
+++ b/meta-isar/recipes-conf/mtda-repo/files/postinst.tmpl
@@ -6,4 +6,4 @@
 
 set -e
 
-echo "deb ${MTDA_APT_URI} * *" > /etc/apt/sources.list.d/mtda.list
+echo "deb ${MTDA_APT_URI} /" > /etc/apt/sources.list.d/mtda.list


### PR DESCRIPTION
- Source list apt-get test:
```
mtda@mtda:~$ cat /etc/apt/sources.list.d/mtda.list
deb https://apt.fury.io/mtda/ * *
mtda@mtda:~$
mtda@mtda:~$ sudo apt update
[sudo] password for mtda:
Hit:1 http://deb.debian.org/debian bookworm InRelease
Get:2 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
Get:3 http://deb.debian.org/debian bookworm-updates InRelease [52.1 kB]
Get:4 https://apt.fury.io/mtda * InRelease
Get:5 http://deb.debian.org/debian-security bookworm-security/main Sources [52.1 kB]
Get:6 http://deb.debian.org/debian-security bookworm-security/main armhf Packages [82.0 kB]
Get:7 http://deb.debian.org/debian-security bookworm-security/main Translation-en [49.2 kB]
Fetched 290 kB in 10s (29.4 kB/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
2 packages can be upgraded. Run 'apt list --upgradable' to see them.
mtda@mtda:~$
```

- Similar list as we add to debian 12 Bookworm

Updated list test:
```
mtda@mtda:~$ cat /etc/apt/sources.list.d/mtda.list
deb https://apt.fury.io/mtda/ /
mtda@mtda:~$ sudo apt update
Hit:1 http://deb.debian.org/debian bookworm InRelease
Hit:2 http://deb.debian.org/debian-security bookworm-security InRelease
Hit:3 http://deb.debian.org/debian bookworm-updates InRelease
Get:4 https://apt.fury.io/mtda  InRelease [1,975 B]
Get:5 https://apt.fury.io/mtda  Packages [228 kB]
Fetched 230 kB in 10s (22.7 kB/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
2 packages can be upgraded. Run 'apt list --upgradable' to see them.

mtda@mtda:~$ apt search mtda
Sorting... Done
Full Text Search... Done
mtda/stable,now 0.23-1 all [installed]
  Multi-Tenant Device Access Multi-Tenant Device Access (or MTDA

mtda-config/stable 0.23-1 all
  Tool to configure MTDA Kconfig-based tool for configuring MTDA

mtda-docker/stable 0.23-1 all
  control docker containers using MTDA Provide drivers to

mtda-hostname/stable,now 0.4 all [installed]
  set system hostname to mtda

mtda-kvm/stable 0.23-1 all
  KVM machine managed by MTDA Provide a KVM machine with a MTDA

mtda-network/stable,now 0.1 all [installed]
  MTDA network configuration using network-manager

mtda-pytest/stable 0.23-1 all
  support for pytest code that uses MTDA Provide helper classes to

mtda-repo/stable,now 0.1 all [installed]
  inject mtda binary package feeds into runtime image

mtda-ui/stable 0.23-1 all
  a simple user-interface for MTDA Provide a simple client-side

mtda-usb-functions/stable 0.5 all
  USB functions for MTDA

mtda-www/stable,now 0.23-1 all [installed]
  web-based user-interface for MTDA Provide a simple web-base

u-boot-script-mtda-bookworm-beaglebone-black/stable 1.1 armhf
  Boot script generator for U-Boot

u-boot-script-mtda-bookworm-nanopi-neo/stable,now 1.1 armhf [installed]
  Boot script generator for U-Boot

u-boot-script-mtda-bookworm-nanopi-r1/stable 1.1 armhf
  Boot script generator for U-Boot

mtda@mtda:~$
```