### PR TITLE
client: support 'storage write' from an S3 bucket

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Package: mtda
 Architecture: all
 Multi-Arch: foreign
 Depends: python3:any (>= 3.7~),
+         python3-boto3,
          python3-daemon,
          python3-gevent,
          python3-libgpiod,

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -108,7 +108,14 @@ command::
 
     $ mtda-cli storage write console-image.wic.bz2
 
-It should be noted that MTDA supports ``.gz``, ``.bz2`` and raw images.
+Images may also be downloaded from a S3 bucket::
+
+    $ export AWS_ACCESS_KEY_ID=my-access-key
+    $ export AWS_SECRET_ACCESS_KEY=my-secret-access-key
+    $ mtda-cli storage write s3://example.org/console-image.wic.zst
+
+It should be noted that MTDA supports ``.gz``, ``.bz2``, ``.zst`` and
+raw images.
 
 Partitions may be mounted on the MTDA host using the ``storage mount``
 command::


### PR DESCRIPTION
The 'storage write' command may now download an image (and its associated .bmap file if it exists) from an S3 bucket. Credentials may be provided in the environment (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY).