### PR TITLE
storage: use exceptions for open/write instead of booleans

### DIFF
--- a/mtda-cli
+++ b/mtda-cli
@@ -352,17 +352,20 @@ class Application:
         return 0
 
     def storage_write(self, args=None):
-        self.start_time = time.monotonic()
-        status = self.agent.storage_write_image(
-            args.image, self._storage_write_cb
-        )
-        sys.stdout.write("\n")
-        sys.stdout.flush()
-
-        if status is False:
-            print("'storage write' failed!", file=sys.stderr)
-            return 1
-        return 0
+        result = 0
+        try:
+            self.start_time = time.monotonic()
+            self.agent.storage_write_image(
+                args.image, self._storage_write_cb
+            )
+            sys.stdout.write("\n")
+            sys.stdout.flush()
+        except Exception as e:
+            msg = e.msg if hasattr(e, 'msg') else str(e)
+            print("\n'storage write' failed! ({})".format(msg),
+                  file=sys.stderr)
+            result = 1
+        return result
 
     def target_uptime(self):
         result = ""

--- a/mtda/storage/helpers/image.py
+++ b/mtda/storage/helpers/image.py
@@ -264,16 +264,11 @@ class Image(StorageController):
         return result
 
     def _open_impl(self):
-        result = True
         if self._status() == CONSTS.STORAGE.ON_HOST:
             if self.handle is None:
-                try:
-                    self.handle = open(self.file, "r+b")
-                    self.handle.seek(0, 0)
-                except FileNotFoundError:
-                    result = False
-
-        return result
+                self.handle = open(self.file, "r+b")
+                self.handle.seek(0, 0)
+        return True
 
     def status(self):
         self.mtda.debug(3, "storage.helpers.image.status()")


### PR DESCRIPTION
Raise and propage exceptions when the shared storage cannot be opened or when a write error occurs instead of returning False. Exceptions raised over ZeroRPC become RemoteError exceptions and the msg attribute holds a human-readable error message.