### PR TITLE
fix some tricky bugs by setting flags at the proper timing and place

### DIFF
--- a/mtda/client.py
+++ b/mtda/client.py
@@ -270,6 +270,7 @@ class Client:
         finally:
             # Storage may be closed now
             self.storage_close()
+            self._impl.storage_bmap_dict(None, self._session)
 
     def parseBmap(self, bmap, bmap_path):
         try:

--- a/mtda/main.py
+++ b/mtda/main.py
@@ -643,7 +643,7 @@ class MultiTenantDeviceAccess:
         self.mtda.debug(3, "main.storage_mount()")
 
         self._session_check(session)
-        if self.storage_controller.static_is_mounted is True:
+        if self.storage.is_storage_mounted is True:
             self.mtda.debug(4, "storage_mount(): already mounted")
             result = True
         elif self.storage is None:

--- a/mtda/main.py
+++ b/mtda/main.py
@@ -643,7 +643,7 @@ class MultiTenantDeviceAccess:
         self.mtda.debug(3, "main.storage_mount()")
 
         self._session_check(session)
-        if self._storage_mounted is True:
+        if self.storage_controller.static_is_mounted is True:
             self.mtda.debug(4, "storage_mount(): already mounted")
             result = True
         elif self.storage is None:

--- a/mtda/storage/helpers/image.py
+++ b/mtda/storage/helpers/image.py
@@ -32,7 +32,7 @@ class BmapWriteError(OSError):
 
 
 class Image(StorageController):
-
+    static_is_mounted = False
     def __init__(self, mtda):
         self.mtda = mtda
         self.handle = None
@@ -130,7 +130,8 @@ class Image(StorageController):
 
         with self.lock:
             result = self._umount()
-
+        if result is True:
+            static_is_mounted = False
         self.mtda.debug(3, "storage.helpers.image.umount(): %s" % str(result))
         return result
 
@@ -227,6 +228,8 @@ class Image(StorageController):
         self.mtda.debug(3, "storage.helpers.image.mount()")
         with self.lock:
             result = self._mount_impl(part)
+        if result is True:
+            static_is_mounted = True
         self.mtda.debug(3, "storage.helpers.image.mount(): %s" % str(result))
         return result
 


### PR DESCRIPTION
```sh

1. mtda-cli -r  $HOST_NAME storage write  1.0.1-installer.wic.xz
2. mtda-cli -r $HOST_NAME storage mount 3
3. mtda-cli -r $HOST_NAME storage update $image_path_in_installer.bmap $bmap_path
4. mtda-cli -r $HOST_NAME storage update $image_path_in_installer.xz $xz_path
5. mtda-cli -r  $HOST_NAME storage target
6. mtda-cli -r  $HOST_NAME target on
7. ...
8. mtda-cli -r  $HOST_NAME target off
9. mtda-cli -r  $HOST_NAME storage host
10. mtda-cli -r  $HOST_NAME storage write  1.0.2-installer.wic.xz
11. mtda-cli -r $HOST_NAME storage mount 3
```

When I run a shell script like above, I found some trick bugs: 

- The 1st commit to fix #267 **  . 
    I encountered the same error sometimes and the error message is just like this issue. 

   So the error in #267  means that there are still  many data to get but _file.flush()_ returned and running _storage_close()_  according to the storage write/update logic. And _storage close_ will wait for the writing thread join **until timeout.** 

    The reason why  _file.flush()_ returned it's the self._writing is **False** at the timeslot when the previous loop in the writing thread ended  but the next loop not started yet.

- The 2nd commit to fix the bug happening at **line 11** in the shell script.

   so we _storage mount_  firstly, and then we call _storage target_ which will umount the storage, but the self._storage_mounted is not set, so mount doesn't work anymore. 

   I add a static_value to set this flag, because it's not a session related, it might be umount by other session, so it should be a static variable in the Class instead of a Class Instance.

- The 3rd commit to fix the bug happening at **line 3** in the shell script.

   so we _storage write_  firstly, and then we call _storage update_. They are in the same session, so when calling _storage update_, the _storage_bmap_dict_ still have a value written by  _storage write_  last time, we  need to reset it after writing

cc @bovi  @chombourger 