### PR TITLE
nanopi-neo: fix mtda image fails to boot due to boot device not found

### DIFF
--- a/kas/common/base.yml
+++ b/kas/common/base.yml
@@ -21,7 +21,7 @@ repos:
       meta-isar:
   isar:
     url: https://github.com/ilbers/isar.git
-    commit: 30471bb3f787fb0aa822d15e141ecce2f3b99860
+    commit: f0ba8583f2db75dd1736c1d2248d5e6bc86ea17b
     layers:
       meta:
       meta-isar:


### PR DESCRIPTION
- Observing boot failure on nanopi-neo, due to dev/mmcblk2p1 not found
- Update the isar to latest revision
- isar commit ref: https://github.com/ilbers/isar/commit/f0ba8583f2db75dd1736c1d2248d5e6bc86ea17b (use part uuid instead of particular dev), fixes boot issue on nanopi-neo

Boot failure logs:
```
Begin: Running /scripts/local-block ... mdadm: No arrays found in config file or automatically
done.
done.
Gave up waiting for root file system device.  Common problems:
 - Boot args (cat /proc/cmdline)
   - Check rootdelay= (did the system wait long enough?)
 - Missing modules (cat /proc/modules; ls /dev)
ALERT!  /dev/mmcblk2p1 does not exist.  Dropping to a shell!
(initramfs)
```

After the fix:
```
Debian GNU/Linux 12 mtda ttyS0

mtda login: mtda
Password:
Linux mtda 6.1.0-13-armmp #1 SMP Debian 6.1.55-1 (2023-09-29) armv7l

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
mtda@mtda:~$ lsblk
NAME        MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
mmcblk0     179:0    0 29.7G  0 disk
└─mmcblk0p1 179:1    0 29.7G  0 part /
mtda@mtda:~$ mtda-cli -v
MTDA version: 0.26
mtda@mtda:~$
```
[complete-boot-logs-neo.txt](https://github.com/siemens/mtda/files/13516855/complete-boot-logs-neo.txt)
