### PR TITLE
feat(main): emit storage locked/unlocked events

### DIFF
--- a/mtda/constants.py
+++ b/mtda/constants.py
@@ -63,6 +63,8 @@ class SESSION:
 class STORAGE:
     ON_HOST = "HOST"
     ON_TARGET = "TARGET"
+    LOCKED = "LOCKED"
+    UNLOCKED = "UNLOCKED"
     UNKNOWN = "???"
 
 

--- a/mtda/power/docker.py
+++ b/mtda/power/docker.py
@@ -223,15 +223,16 @@ class DockerPowerController(PowerController):
     def _status(self):
         self.mtda.debug(3, "power.docker._status()")
 
-        result = self.POWER_UNSURE
-        status = self._container.status
-        if status == "running":
-            result = self.POWER_ON
-        elif status == "created" or status == "exited":
-            result = self.POWER_OFF
-        else:
-            self.mtda.debug(1, "power.docker._status(): "
-                            "unknown status: {}".format(status))
+        result = self.POWER_OFF
+        if self._container is not None:
+            status = self._container.status
+            if status == "running":
+                result = self.POWER_ON
+            elif status == "created" or status == "exited":
+                result = self.POWER_OFF
+            else:
+                self.mtda.debug(1, "power.docker._status(): "
+                                "unknown status: {}".format(status))
 
         self.mtda.debug(3, "power.docker._status(): {}".format(result))
         return result

--- a/mtda/templates/index.html
+++ b/mtda/templates/index.html
@@ -156,7 +156,7 @@ SPDX-License-Identifier: MIT
       });
 
       socket.on("video-info", function (info) {
-	if (info.format == 'VNC') {
+        if (info.format == 'VNC') {
           vnc_load()
         }
         else {
@@ -188,7 +188,13 @@ SPDX-License-Identifier: MIT
       });
 
       socket.on("storage-event", (data) => {
-        switch(data.event) {
+        data = data.event.split(" ")
+        event = data[0]
+        data = data.splice(1).join(" ")
+	if (event == 'UNLOCKED') {
+	  event = data
+	}
+        switch(event) {
           case 'HOST':
             storage_status.innerHTML = "save";
             storage_status.title = "switch storage to target"
@@ -196,6 +202,10 @@ SPDX-License-Identifier: MIT
           case 'TARGET':
             storage_status.innerHTML = "eject";
             storage_status.title = "switch storage to host"
+            break;
+          case 'LOCKED':
+            storage_status.innerHTML = "no_sim";
+            storage_status.title = data
             break;
           default:
             storage_status.innerHTML = "unknown_document"


### PR DESCRIPTION
Tell user interface(s) when storage gets locked/unlocked to enable or disable the storage swap button they may provide. Such events are triggered from power on/off and storage open/close operations.