### PR TITLE
chore(keyboard): handle special keys in main

### DIFF
--- a/mtda/keyboard/hid.py
+++ b/mtda/keyboard/hid.py
@@ -240,29 +240,6 @@ class HidKeyboardController(KeyboardController):
             '{': 0x2f, '}': 0x30, '|': 0x31, ':': 0x33, '"': 0x34, '~': 0x35,
             '<': 0x36, '>': 0x37, '?': 0x38
         }
-        special_keys = {
-            '<down>': 0x51,
-            '<enter>': 0x28,
-            '<esc>': 0x29,
-            '<f1>': 0x3a,
-            '<f2>': 0x3b,
-            '<f3>': 0x3c,
-            '<f4>': 0x3d,
-            '<f5>': 0x3e,
-            '<f6>': 0x3f,
-            '<f7>': 0x40,
-            '<f8>': 0x41,
-            '<f9>': 0x42,
-            '<f10>': 0x43,
-            '<f11>': 0x44,
-            '<f12>': 0x45,
-            '<left>': 0x50,
-            '<right>': 0x4f,
-            '<up>': 0x52
-        }
-
-        if what in special_keys:
-            return self.press(special_keys[what])
 
         for k in what:
             if k in lower_keys:

--- a/mtda/main.py
+++ b/mtda/main.py
@@ -468,15 +468,47 @@ class MultiTenantDeviceAccess:
         self.mtda.debug(3, "env_set(): %s" % str(result))
         return result
 
-    def keyboard_write(self, input_str, session=None):
+    def keyboard_write(self, what, session=None):
         self.mtda.debug(3, "main.keyboard_write()")
 
         self._session_check(session)
         result = None
         if self.keyboard is not None:
-            result = self.keyboard.write(input_str)
+            special_keys = {
+                    "<down>": self.keyboard.down,
+                    "<enter>": self.keyboard.enter,
+                    "<esc>": self.keyboard.esc,
+                    "<f1>": self.keyboard.f1,
+                    "<f2>": self.keyboard.f2,
+                    "<f3>": self.keyboard.f3,
+                    "<f4>": self.keyboard.f4,
+                    "<f5>": self.keyboard.f5,
+                    "<f6>": self.keyboard.f6,
+                    "<f7>": self.keyboard.f7,
+                    "<f8>": self.keyboard.f8,
+                    "<f9>": self.keyboard.f9,
+                    "<f10>": self.keyboard.f10,
+                    "<f11>": self.keyboard.f11,
+                    "<f12>": self.keyboard.f12,
+                    "<left>": self.keyboard.left,
+                    "<right>": self.keyboard.right,
+                    "<up>": self.keyboard.up
+                    }
 
-        self.mtda.debug(3, "main.keyboard_write(): %s" % str(result))
+            while what != "":
+                # check for special keys such as <esc>
+                if what.startswith('<') and '>' in what:
+                    key = what.split('>')[0] + '>'
+                    if key in special_keys:
+                        offset = len(key)
+                        what = what[offset:]
+                        special_keys[key]()
+                        continue
+                key = what[0]
+                what = what[1:]
+                self.keyboard.write(key)
+
+        self.mtda.debug(3, "main.keyboard_write(): {}".format(result))
         return result
 
     def monitor_remote(self, host, screen):


### PR DESCRIPTION
The hid keyboard driver understands <esc>, <left>, <right>, <down>, <up> and function keys as special keys. Move this handling in main for other drivers (such as qemu) to also handle these special keys as users of keyboard.write() may reasonably expect.