### PR TITLE
debian: do not call mtda-systemd-helper when running in chroot

### DIFF
--- a/debian/mtda-service.postinst
+++ b/debian/mtda-service.postinst
@@ -6,7 +6,7 @@
 case "$1" in
 
   configure)
-    /usr/sbin/mtda-systemd-helper || exit ${?}
+    ischroot || /usr/sbin/mtda-systemd-helper || exit ${?}
     if ! grep -qe '^libcomposite$' /etc/modules; then
       echo "libcomposite" >/etc/modules || exit ${?}
     fi


### PR DESCRIPTION
Closes: #397