### PR TITLE
power/gpio: Allow to configure low level triggered relays

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -262,10 +262,14 @@ supported:
     Format: <gpiochipx>@<pin>
     If multiple GPIO lines and pins are used separate the entries using ','.
 
+* ``enable``: string [optional]
+    If the relay enable trigger is ``high`` or ``low``. Defaults to ``high``.
+
     Example::
 
         # For single GPIO line
         gpio = gpiochip0@201
+        enable = high
         # For multiple GPIO lines
         gpio = gpiochip0@201,gpiochip1@11,gpiochip0@203
 

--- a/mtda.ini
+++ b/mtda.ini
@@ -132,7 +132,8 @@ time-until = login:
 variant=aviosys_8800
 
 # variant=gpio
-# pins=48
+# gpio=gpiochip0@203
+# enable=high
 
 # variant=pduclient
 # daemon=134.86.60.40


### PR DESCRIPTION
Introduce an optional `enable` config key for the power gpio. This config defaults to `high` for high level triggered relays but can be set to `low` for low level triggered relays.