### PR TITLE
fix(www): Disable browser shortcuts

### DIFF
--- a/mtda/templates/index.html
+++ b/mtda/templates/index.html
@@ -109,8 +109,9 @@ SPDX-License-Identifier: MIT
     <script src="./assets/keysight.js"></script>
     <script type=text/javascript>
       window.addEventListener("keydown", function(event) {
-        var key = keysight(event).char
-        console.log("#### <KEY> " + key)
+        var key = keysight(event).char;
+        event.preventDefault();
+        console.log("#### <KEY> " + key);
         $.getJSON('./keyboard-input', {input: key}, function(key) {
           // do nothing
         });


### PR DESCRIPTION
The default browser keyboard actions interfere with the keyboard based interaction with the device. Disable them for the MTDA web interface.