### PR TITLE
feat(www): Enable the usage of modifier keys

### DIFF
--- a/mtda/assets/keysight.js
+++ b/mtda/assets/keysight.js
@@ -60,7 +60,7 @@
                 12: "num",
                 13: "\n",
                 16: "shift",
-                17: "meta",
+                17: "ctrl",
                 18: "alt",
                 19: "pause",
                 20: "caps",
@@ -156,7 +156,11 @@
             else var f = t.toUpperCase();
             return {
                 "char": f,
-                key: t
+                key: t,
+                ctrl: e.ctrlKey,
+                shift: e.shiftKey,
+                alt: e.altKey,
+                cmd: e.metaKey,
             }
         }, e.exports.unprintableKeys = {
             "\b": 1,

--- a/mtda/keyboard/controller.py
+++ b/mtda/keyboard/controller.py
@@ -64,6 +64,10 @@ class KeyboardController(object):
         return False
 
     @abc.abstractmethod
+    def press(self, key, repeat=1, ctrl=False, shift=False, alt=False, meta=False):
+        return False
+
+    @abc.abstractmethod
     def write(self, str):
         return
 

--- a/mtda/keyboard/qemu.py
+++ b/mtda/keyboard/qemu.py
@@ -39,7 +39,7 @@ class QemuController(KeyboardController):
     def idle(self):
         return True
 
-    def press(self, key, repeat=1):
+    def press(self, key, repeat=1, ctrl=False, shift=False, alt=False, meta=False):
         self.mtda.debug(3, "keyboard.qemu.press()")
 
         symbols = {
@@ -54,11 +54,21 @@ class QemuController(KeyboardController):
                 '\n': 'ret'
                 }
 
+        mod = ""
+        if ctrl:
+            mod = "ctrl-"
+        if shift:
+            mod = f"{mod}shift-"
+        if alt:
+            mod = f"{mod}alt-"
+        if meta:
+            mod = f"{mod}meta_l-"
+
         result = True
         while repeat > 0:
             repeat = repeat - 1
             key = symbols[key] if key in symbols else key
-            self.qemu.cmd(f"sendkey {key}")
+            self.qemu.cmd(f"sendkey {mod}{key}")
             time.sleep(0.1)
         return result
 

--- a/mtda/templates/index.html
+++ b/mtda/templates/index.html
@@ -106,10 +106,15 @@ SPDX-License-Identifier: MIT
     <script src="./assets/keysight.js"></script>
     <script type=text/javascript>
       window.addEventListener("keydown", function(event) {
-        var key = keysight(event).char;
-        event.preventDefault();
-        console.log("#### <KEY> " + key);
-        $.getJSON('./keyboard-input', {input: key}, function(key) {
+        var key = keysight(event)
+        console.log("#### <KEY> " + JSON.stringify(key))
+        $.getJSON('./keyboard-input', {
+          input: key.char,
+          ctrl:  key.ctrl,
+          shift: key.shift,
+          alt:   key.alt,
+          meta:  key.cmd,
+        }, function(key) {
           // do nothing
         });
       });

--- a/mtda/www.py
+++ b/mtda/www.py
@@ -104,7 +104,13 @@ def keyboard_input():
             if input in map:
                 map[input]()
         else:
-            mtda.keyboard.write(input)
+            mtda.keyboard.press(
+                input,
+                ctrl=request.args.get('ctrl', False, type=lambda s: s == 'true'),
+                shift=request.args.get('shift', False, type=lambda s: s == 'true'),
+                alt=request.args.get('alt', False, type=lambda s: s == 'true'),
+                meta=request.args.get('meta', False, type=lambda s: s == 'true')
+            )
     return ''
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,3 +26,4 @@ commands =
 
 [flake8]
 exclude = dist,docs,*.egg-info,__pycache__
+max-line-length = 120


### PR DESCRIPTION
Expose a press function in the keyboard controller that handles the press of a single key with modifier keys. Use this function from the web UI to allow to hit key combinations like ctrl-c.

Can please somebody test this with qemu? I do not have a running qemu setup atm.