### PR TITLE
kas/common/base: update isar to latest revision

### DIFF
--- a/kas/common/base.yml
+++ b/kas/common/base.yml
@@ -21,7 +21,7 @@ repos:
       meta-isar:
   isar:
     url: https://github.com/ilbers/isar.git
-    commit: f0ba8583f2db75dd1736c1d2248d5e6bc86ea17b
+    commit: ac9b9031fcaad47b7163598924198954f6523e3f
     layers:
       meta:
       meta-isar:

--- a/meta-isar/recipes-bsp/rpi-firmware/files/rules
+++ b/meta-isar/recipes-bsp/rpi-firmware/files/rules
@@ -5,3 +5,6 @@ override_dh_auto_build:
 
 %:
 	dh $@
+
+override_dh_strip:
+override_dh_dwz:

--- a/meta-isar/recipes-crypto/gnutls/gnutls28.bb
+++ b/meta-isar/recipes-crypto/gnutls/gnutls28.bb
@@ -8,7 +8,7 @@
 inherit dpkg
 
 SRC_URI = "apt://${PN} \
-           file://changelog.tmpl"
+           file://changelog.tmpl "
 
 DEB_BUILD_OPTIONS += "nocheck"
 


### PR DESCRIPTION
- Update to latest ISAR revision
- Use SRC_APT for apt packages (vs SRC_URI). Here, for gnutls package.
- Rpi-firmware: Consists of .elf binary files
      Avoid striping it or strip dwarf debug information
      Fixes build failure

Nano pi build and boot tested:
Nanopi neo booting fine. Boot logs:
[mtda-latest-isar.txt](https://github.com/siemens/mtda/files/14540227/mtda-latest-isar.txt)
