### PR TITLE
ci: update actions to latest version and fix nodejs deprecated warning

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -19,4 +19,4 @@ jobs:
   add-reviews:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v1.2.5
+      - uses: kentaro-m/auto-assign-action@v2.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: tox
         run: |
           sudo apt install -y build-essential libsystemd-dev
@@ -37,11 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Free Disk Space
         uses: ./.github/workflows/free-disk-space
       - name: Cache downloads and sstate
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ hashFiles('debian/changelog') }}
           path: |
@@ -56,7 +56,7 @@ jobs:
         run: |
           ./kas-container build kas/ci/full.yml
       - name: Upload NanoPI images
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: github.ref == 'refs/heads/master'
         with:
           name: mtda-nanopi-images
@@ -64,7 +64,7 @@ jobs:
             build/tmp/deploy/images/nanopi-*/mtda-image-mtda-*-nanopi-*.wic
             build/tmp/deploy/images/nanopi-*/mtda-image-mtda-*-nanopi-*.wic.bmap
       - name: Upload BeagleBone Black images
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: github.ref == 'refs/heads/master'
         with:
           name: mtda-bbb-images
@@ -82,7 +82,7 @@ jobs:
       - name: Import GPG key
         if: startsWith(github.ref, 'refs/tags/v')
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v4
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -25,9 +25,9 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
     - name: Install pypa/build

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rojopolis/spellcheck-github-actions@0.34.0
+      - uses: rojopolis/spellcheck-github-actions@v0
         name: Spellcheck
         with:
           config_path: .github/spellcheck_config.yml


### PR DESCRIPTION
Update github actions to:
- kentaro-m/auto-assign-action: 2.0.0
- actions/checkout: 4
- actions/cache: 4
- actions/upload-artifact: 4
- actions/setup-python: 5
- crazy-max/ghaction-import-gpg: 6
- rojopolis/spellcheck-github-actions: v0

Fixes: Warnings: Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20