### PR TITLE
kas/common/base.yml: enable use of ccache for the builds

### DIFF
--- a/kas/common/base.yml
+++ b/kas/common/base.yml
@@ -36,3 +36,5 @@ local_conf_header:
   base: |
     CONF_VERSION = "1"
     ISAR_CROSS_COMPILE = "1"
+  ccache: |
+    USE_CCACHE = "1"


### PR DESCRIPTION
- Enable Compiler cache for the builds
- It reduces build time during recompilation by caching previous compilations, and detecting when same compilation is being done again
- Tested nanopi neo image build time got reduced by 5 minutes


Build tests:
```
Without ccache:
Loaded 0 entries from dependency cache.
Parsing recipes: 100% |######################################################################################################################################################################################################| Time: 0:00:00
Parsing of 76 .bb files complete (0 cached, 76 parsed). 128 targets, 15 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies
Initialising tasks: 100% |###################################################################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 20 Local 0 Mirrors 0 Missed 20 Current 0 (0% match, 0% complete)
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 216 tasks of which 0 didn't need to be rerun and all succeeded.

real    17m0.770s
user    0m0.180s
sys     0m0.132s


# with cache
Parsing recipes: 100% |######################################################################################################################################################################################################| Time: 0:00:00
Parsing of 76 .bb files complete (0 cached, 76 parsed). 128 targets, 15 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies
Initialising tasks: 100% |###################################################################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 20 Local 0 Mirrors 0 Missed 20 Current 0 (0% match, 0% complete)
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 216 tasks of which 0 didn't need to be rerun and all succeeded.

real    12m23.131s
user    0m0.089s
sys     0m0.158s
```