### PR TITLE
ci(assign): define permissions for auto assign workflow

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -15,6 +15,10 @@ on:
   pull_request:
     types: [opened, ready_for_review]
 
+permissions:
+  contents: read # to read configuration file
+  pull-requests: write # to assign PRs
+
 jobs:
   add-reviews:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Explicitely stating required permissions is considered best practice.
This case was detected by Poutine, see
https://github.com/boostsecurityio/poutine/blob/main/docs/content/en/rules/default_permissions_on_risky_events.md.

Signed-off-by: Florian Greinacher <florian.greinacher@siemens.com>