### PR TITLE
meta-isar/recipes-python: upgrade python-zstandard to 0.22.0

### DIFF
--- a/meta-isar/recipes-python/compression/python-zstandard/debian-compat.patch
+++ b/meta-isar/recipes-python/compression/python-zstandard/debian-compat.patch
@@ -1,12 +1,12 @@
-diff -ur python-zstandard-0.21.0.orig/debian/compat python-zstandard-0.21.0/debian/compat
---- python-zstandard-0.21.0.orig/debian/compat	2023-08-29 07:53:13.471345710 +0200
-+++ python-zstandard-0.21.0/debian/compat	2023-08-29 07:53:46.211650713 +0200
+diff -ur python-zstandard-0.22.0.orig/debian/compat python-zstandard-0.22.0/debian/compat
+--- python-zstandard-0.22.0.orig/debian/compat	2023-08-29 07:53:13.471345710 +0200
++++ python-zstandard-0.22.0/debian/compat	2023-08-29 07:53:46.211650713 +0200
 @@ -1 +1 @@
 -7
 +10
-diff -ur python-zstandard-0.21.0.orig/debian/rules python-zstandard-0.21.0/debian/rules
---- python-zstandard-0.21.0.orig/debian/rules	2023-08-29 07:53:13.471345710 +0200
-+++ python-zstandard-0.21.0/debian/rules	2023-08-29 07:53:52.421708602 +0200
+diff -ur python-zstandard-0.22.0.orig/debian/rules python-zstandard-0.22.0/debian/rules
+--- python-zstandard-0.22.0.orig/debian/rules	2023-08-29 07:53:13.471345710 +0200
++++ python-zstandard-0.22.0/debian/rules	2023-08-29 07:53:52.421708602 +0200
 @@ -1,9 +1,6 @@
  #!/usr/bin/make -f
  
@@ -17,9 +17,9 @@ diff -ur python-zstandard-0.21.0.orig/debian/rules python-zstandard-0.21.0/debia
  
  %:
  	dh $@ --parallel --with python3 --buildsystem=pybuild
-diff -ur python-zstandard-0.21.0.orig/debian/source/format python-zstandard-0.21.0/debian/source/format
---- python-zstandard-0.21.0.orig/debian/source/format	2023-08-29 07:53:27.591477132 +0200
-+++ python-zstandard-0.21.0/debian/source/format	2023-08-29 07:40:17.973822478 +0200
+diff -ur python-zstandard-0.22.0.orig/debian/source/format python-zstandard-0.22.0/debian/source/format
+--- python-zstandard-0.22.0.orig/debian/source/format	2023-08-29 07:53:27.591477132 +0200
++++ python-zstandard-0.22.0/debian/source/format	2023-08-29 07:40:17.973822478 +0200
 @@ -1 +1 @@
 -3.0 (quilt)
 +3.0 (native)

--- a/meta-isar/recipes-python/compression/python-zstandard_0.22.0.bb
+++ b/meta-isar/recipes-python/compression/python-zstandard_0.22.0.bb
@@ -9,7 +9,7 @@ inherit dpkg
 
 GH_URI  = "https://github.com/indygreg/${PN}/archive/refs/tags/${PV}.tar.gz"
 SRC_URI = "${GH_URI} file://debian-compat.patch"
-SRC_URI[sha256sum] = "15adc6bfa629d48b0bb658e9eae94c484adb66a28738fa780478eebeb41599a5"
+SRC_URI[sha256sum] = "34ce7ef020afca1344c538a778e2a2e30dc43b11509aa4cb5cf076228d959ca7"
 
 DEB_BUILD_OPTIONS  = "nocheck"
 ISAR_CROSS_COMPILE = "0"


### PR DESCRIPTION
New upstream release 0.22.0


Test logs:
```
bp@ipc847e:~/zstandard/mtda$ ./kas-container build kas/ubuntu/mtda-qemu-amd64.yml
2024-06-26 16:12:50 - INFO     - kas 4.3.1 started
2024-06-26 16:12:50 - INFO     - Using /repo as root for repository mtda
2024-06-26 16:12:50 - INFO     - Repository isar already contains ac9b9031fcaad47b7163598924198954f6523e3f as commit
2024-06-26 16:12:50 - INFO     - Repository isar checked out to ac9b9031fcaad47b7163598924198954f6523e3f
2024-06-26 16:12:50 - INFO     - /build$ /work/isar/bitbake/bin/bitbake -c build mtda-image
Loading cache: 100% |                                                                                                                                                                            | ETA:  --:--:--
Loaded 0 entries from dependency cache.
Parsing recipes: 100% |###########################################################################################################################################################################| Time: 0:00:00
Parsing of 76 .bb files complete (0 cached, 76 parsed). 79 targets, 15 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies
Initialising tasks: 100% |########################################################################################################################################################################| Time: 0:00:00
Sstate summary: Wanted 20 Local 0 Mirrors 0 Missed 20 Current 0 (0% match, 0% complete)
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 218 tasks of which 0 didn't need to be rerun and all succeeded.

bp@ipc847e:~/zstandard/mtda/build/tmp/deploy/images/qemuamd64$ grep zstandard mtda-image-ubuntu-jammy-qemuamd64.manifest
python-zstandard|0.22.0|python3-zstandard|0.22.0
```

However, this recipe may no longer needed, once we move to ubuntu 24.04 LTS, as this package is available in the repo. Ref: https://packages.ubuntu.com/search?keywords=python3-zstandard