### PR TITLE
fix: anel.py declare result in front of exception

### DIFF
--- a/mtda/power/anel.py
+++ b/mtda/power/anel.py
@@ -80,6 +80,7 @@ class AnelPowerController(PowerController):
         payload = f"Sw_{'on' if state else 'off'}{self._plug}"
         self._send(payload)
 
+        result = None
         try:
             result = self._receive().split(':')[5+self._plug].rsplit(',', 1)[1]
         except TimeoutError:


### PR DESCRIPTION
result is unbound if _receive times out with the follow exeception:

mtda-mcom mtda-service[1400]:     self._switch(False)
mtda-mcom mtda-service[1400]:   File "/usr/lib/python3.11/dist-packages/mtda/power/anel.py", line 88, in _switch
mtda-mcom mtda-service[1400]:     if result == "0":
mtda-mcom mtda-service[1400]:        ^^^^^^
mtda-mcom mtda-service[1400]: UnboundLocalError: cannot access local variable 'result' where it is not associated with a value