### PR TITLE
fix(build): switch to isar next to fix ubuntu noble builds

### DIFF
--- a/kas/common/base.yml
+++ b/kas/common/base.yml
@@ -21,7 +21,7 @@ repos:
       meta-isar:
   isar:
     url: https://github.com/ilbers/isar.git
-    commit: fe7f6a94ebc040fd1220f03056e2d6312b48f25d
+    commit: 483093e11cd722f0c88dc2fcbed1e937fc0abb60
     layers:
       meta:
       meta-isar:


### PR DESCRIPTION
The version of Isar we were on is trying to forcibly install the usrmerge package while it was removed in Ubuntu Noble. This was fixed upstream in the next branch: switched to it for the time being.

See: https://groups.google.com/g/isar-users/c/c_d8103JlRY