### PR TITLE
fix(docs): update config file name in install docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -56,10 +56,10 @@ Docker and KVM may be used as virtual platforms by respectively installing the m
 
     $ sudo apt-get install mtda-docker
     $ sudo mkdir -p /etc/mtda/
-    $ sudo cp /usr/share/doc/mtda-docker/examples/docker.ini /etc/mtda/config
+    $ sudo cp /usr/share/doc/mtda-docker/examples/mtda.ini /etc/mtda/config
 
 `mtda-kvm` may be installed as follows::
 
     $ sudo apt-get install mtda-kvm
     $ sudo mkdir -p /etc/mtda/
-    $ sudo cp /usr/share/doc/mtda-kvm/examples/qemu.ini /etc/mtda/config
+    $ sudo cp /usr/share/doc/mtda-kvm/examples/mtda.ini /etc/mtda/config


### PR DESCRIPTION
The installation documentation needs to be updated to use the correct
 configuration file names for the Docker and KVM virtual platforms.
 The configuration files are now named mtda.ini instead of docker.ini
 and qemu.ini, respectively.