### PR TITLE
feat(storage): no longer require a password when spawning nbd-client

### DIFF
--- a/debian/mtda-client.postinst
+++ b/debian/mtda-client.postinst
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if ! getent group mtda >/dev/null; then
+    addgroup --system mtda
+fi

--- a/debian/mtda-client.sudoers
+++ b/debian/mtda-client.sudoers
@@ -1,0 +1,3 @@
+%mtda ALL=(ALL) NOPASSWD: /usr/sbin/modprobe nbd
+%mtda ALL=(ALL) NOPASSWD: /usr/sbin/nbd-client -N mtda-storage [A-Za-z0-9.-]*
+%mtda ALL=(ALL) NOPASSWD: /usr/sbin/nbd-client -d /dev/nbd[0-9]*

--- a/debian/rules
+++ b/debian/rules
@@ -44,6 +44,8 @@ override_dh_auto_install:
 	mv debian/mtda-service/usr/bin/mtda-cli debian/mtda-client/usr/bin/
 	install -m 0755 -d debian/mtda-client$(MTDA_DIST)/
 	mv debian/mtda-service$(MTDA_DIST)/client.py debian/mtda-client$(MTDA_DIST)/
+	install -m 0755 -d debian/mtda-client/etc/sudoers.d/
+	install -m 0644 debian/mtda-client.sudoers debian/mtda-client/etc/sudoers.d/mtda-client
 	:
 	install -m 0755 -d debian/mtda-common$(MTDA_DIST)/
 	mv debian/mtda-service$(MTDA_DIST)/constants.py debian/mtda-common$(MTDA_DIST)/

--- a/mtda/client.py
+++ b/mtda/client.py
@@ -109,6 +109,9 @@ class Client:
         if rdev is None:
             raise RuntimeError('could not put storage on network')
 
+        cmd = ['sudo', '/usr/sbin/modprobe', 'nbd']
+        subprocess.check_call(cmd)
+
         cmd = ['sudo', cmd, '-N', 'mtda-storage', remote]
         subprocess.check_call(cmd)
 


### PR DESCRIPTION
Ship some sudoers rules to let users belonging to the "mtda" group attach a network block device without a password.