### PR TITLE
fix(pytest): do not fail if the default TEST_IMAGE cannot be found

### DIFF
--- a/mtda/pytest.py
+++ b/mtda/pytest.py
@@ -43,12 +43,16 @@ class Test:
         # Initialize boot media
         image = os.getenv("TEST_IMAGE", Consts.DEFAULT_IMAGE)
         if os.path.exists(image) is False:
-            return False
+            if image != Consts.DEFAULT_IMAGE:
+                return False
+            else:
+                image = ""
 
-        Storage.to_host()
-        Storage.write(image)
-        Storage.to_target()
-        Env.set("boot-from-usb", "1")
+        if image:
+            Storage.to_host()
+            Storage.write(image)
+            Storage.to_target()
+            Env.set("boot-from-usb", "1")
 
         return True
 


### PR DESCRIPTION
Target is our pytest module expects the image specified in the TEST_IMAGE environment variable (or its default value) to exist. No longer fail if an image is not specified in the environment and if the default one could not be found: this may be intented.