### PR TITLE
fix(main): remove etcdir if only exists

### DIFF
--- a/mtda/main.py
+++ b/mtda/main.py
@@ -1017,7 +1017,7 @@ class MultiTenantDeviceAccess:
                 f.write(f'Environment=HOST={self._www_host} PORT={self._www_port}\n')
         else:
             import shutil
-            shutil.rmtree(etcdir)
+            shutil.rmtree(etcdir, ignore_errors=True)
 
         self.mtda.debug(3, f"main.systemd_configure_www(): {result}")
         return result


### PR DESCRIPTION
While installing mtda .deb package on Debian 12 host, observed following traceback
```
Setting up mtda-service (0.36-0) ...
Traceback (most recent call last):
  File "/usr/sbin/mtda-systemd-helper", line 67, in <module>
    sys.exit(app.main())
             ^^^^^^^^^^
  File "/usr/sbin/mtda-systemd-helper", line 57, in main
    self.agent.systemd_configure()
  File "/usr/lib/python3.11/dist-packages/mtda/main.py", line 973, in systemd_configure
    self.systemd_configure_www()
  File "/usr/lib/python3.11/dist-packages/mtda/main.py", line 1020, in systemd_configure_www
    shutil.rmtree(etcdir)
  File "/usr/lib/python3.11/shutil.py", line 722, in rmtree
    onerror(os.lstat, path, sys.exc_info())
  File "/usr/lib/python3.11/shutil.py", line 720, in rmtree
    orig_st = os.lstat(path, dir_fd=dir_fd)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/etc/systemd/system/mtda-www.service.d/'
```