### PR TITLE
A couple of improvements for the RPI4b target

### DIFF
--- a/meta-isar/conf/machine/rpi4b.conf
+++ b/meta-isar/conf/machine/rpi4b.conf
@@ -13,7 +13,7 @@ IMAGE_FSTYPES ?= "wic"
 WKS_FILE ?= "rpi4b.wks"
 
 IMAGER_BUILD_DEPS = "rpi-firmware linux-image-${KERNEL_NAME}"
-IMAGER_INSTALL += "${IMAGER_BUILD_DEPS}"
+IMAGER_INSTALL:wic += "${IMAGER_BUILD_DEPS}"
 
 IMAGE_BOOT_FILES = " \
     /usr/lib/rpi-firmware/bootcode.bin;bootcode.bin \

--- a/meta-isar/recipes-bsp/rpi-firmware/rpi-firmware_1.20250305.bb
+++ b/meta-isar/recipes-bsp/rpi-firmware/rpi-firmware_1.20250305.bb
@@ -11,7 +11,7 @@ SRC_URI = " \
     https://github.com/raspberrypi/firmware/archive/${PV}.tar.gz;downloadfilename=${PN}-${PV}.tar.gz \
     file://debian \
     file://rules"
-SRC_URI[sha256sum] = "67c49b6f2fbf4ee612536b3fc24e44ab3fa9584c78224865699f1cbc1b8eea3c"
+SRC_URI[sha256sum] = "4981021b82f600f450d64d9b82034dc603bf5429889a3947b2863e01992a343c"
 
 S = "${WORKDIR}/firmware-${PV}"
 

--- a/meta-isar/scripts/lib/wic/canned-wks/rpi4b.wks
+++ b/meta-isar/scripts/lib/wic/canned-wks/rpi4b.wks
@@ -5,9 +5,9 @@
 # SPDX-License-Identifier: MIT
 # ---------------------------------------------------------------------------
 
-part --source bootimg-partition --ondisk mmcblk0 --fstype vfat --label boot --align 1 --size 128 --overhead-factor 1 --extra-space 0
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype vfat --label boot --align 1 --size 128 --overhead-factor 1 --extra-space 0
 
-part / --source rootfs --fstype ext4 --mkfs-extraopts "-T default" --label platform --align 1024 --active
+part / --source rootfs --ondisk mmcblk0 --fstype ext4 --mkfs-extraopts "-T default" --label platform --align 1024 --active --exclude-path=boot/
 
 # silence wic
 bootloader


### PR DESCRIPTION
For details, see the commit messages.

Unfortunately for kernels < 6.5 we still can't use the DTB overlays, as the device tree of the `bcm2711-rpi*` targets does not contain the symbol information.