### PR TITLE
fix(rpi4): add overlays needed for efi booting

### DIFF
--- a/meta-isar/conf/machine/rpi4b-efi.conf
+++ b/meta-isar/conf/machine/rpi4b-efi.conf
@@ -14,7 +14,7 @@ KERNEL_NAME ?= "arm64"
 IMAGE_FSTYPES ?= "wic"
 WKS_FILE ?= "rpi4b-efi.wks"
 
-IMAGER_BUILD_DEPS = "rpi-firmware rpi4-edk2-firmware linux-image-${KERNEL_NAME}"
+IMAGER_BUILD_DEPS = "rpi4-edk2-firmware"
 IMAGER_INSTALL:wic += "${IMAGER_BUILD_DEPS} ${SYSTEMD_BOOTLOADER_INSTALL}"
 
 IMAGE_EFI_BOOT_FILES = " \
@@ -24,7 +24,6 @@ IMAGE_EFI_BOOT_FILES = " \
     /usr/lib/rpi-firmware/start4.elf;start4.elf \
     /usr/lib/rpi-firmware/overlays/*;overlays/ \
     /usr/lib/rpi-firmware/bcm2711-rpi-4-b.dtb;bcm2711-rpi-4-b.dtb \
-    /usr/lib/rpi-firmware/overlays/*;overlays/ \
 "
 
 IMAGE_PREINSTALL:append = " firmware-brcm80211"

--- a/meta-isar/recipes-bsp/rpi-firmware/files/debian/rpi-firmware.install
+++ b/meta-isar/recipes-bsp/rpi-firmware/files/debian/rpi-firmware.install
@@ -5,5 +5,9 @@ boot/*.dtb			usr/lib/rpi-firmware/
 boot/*.elf			usr/lib/rpi-firmware/
 boot/overlays/README		usr/lib/rpi-firmware/overlays/
 boot/overlays/aliases.dtbo	usr/lib/rpi-firmware/overlays/
+boot/overlays/dwc2.dtbo		usr/lib/rpi-firmware/overlays/
+boot/overlays/disable-bt.dtbo	usr/lib/rpi-firmware/overlays/
+boot/overlays/uart2.dtbo	usr/lib/rpi-firmware/overlays/
+boot/overlays/vc4-kms-v3d-pi4.dtbo	usr/lib/rpi-firmware/overlays/
 debian/cmdline.txt		usr/lib/rpi-firmware/
 debian/config.txt		usr/lib/rpi-firmware/


### PR DESCRIPTION
These overlays somehow got lost during rebasing. We need them as otherwise the target does not boot.
    
Fixes: 41e6584 ("feat(rpi4): add target to support EFI booting")