### PR TITLE
fix(rpi): install correct device tree

### DIFF
--- a/meta-isar/conf/machine/rpi4b.conf
+++ b/meta-isar/conf/machine/rpi4b.conf
@@ -12,7 +12,7 @@ KERNEL_NAME ?= "arm64"
 IMAGE_FSTYPES ?= "wic"
 WKS_FILE ?= "rpi4b.wks"
 
-IMAGER_BUILD_DEPS = "rpi-firmware linux-image-${KERNEL_NAME}"
+IMAGER_BUILD_DEPS = "rpi-firmware"
 IMAGER_INSTALL:wic += "${IMAGER_BUILD_DEPS}"
 
 IMAGE_BOOT_FILES = " \
@@ -24,8 +24,8 @@ IMAGE_BOOT_FILES = " \
     /usr/lib/rpi-firmware/start4.elf;start4.elf \
     /usr/lib/rpi-firmware/start4x.elf;start4x.elf \
     /usr/lib/rpi-firmware/overlays/*;overlays/ \
-    /usr/lib/linux-image-*/broadcom/bcm2711-rpi-4-b.dtb \
-    /usr/lib/linux-image-*/overlays/*;overlays/ \
+    ${IMAGE_ROOTFS}/usr/lib/linux-image-*/broadcom/bcm2711-rpi-4-b.dtb \
+    ${IMAGE_ROOTFS}/usr/lib/linux-image-*/overlays/*;overlays/ \
     ${IMAGE_ROOTFS}/vmlinuz;kernel8.img \
     ${IMAGE_ROOTFS}/initrd.img;initrd.img \
     "


### PR DESCRIPTION
The imaging in ISAR happens in cross-mode. By that, the IMAGER_INSTALL packages are also installed in a cross chroot. However, the used apt pinnings only pin for the :native architecture. By that, the installed device tree is actually from a 6.1 kernel, while we run a 6.12 kernel in the image. This issue could be solved by pinning `linux-image-*:any`, however all this is not needed as we can just copy the device tree from the image rootfs. By that, we also can be sure that the DT matches the kernel.

Fixes: 1d3c93a ("feat: switch to 6.12 kernel from bookworm backports")