### PR TITLE
feat: add key to print help message

### DIFF
--- a/mtda-cli
+++ b/mtda-cli
@@ -120,6 +120,8 @@ class Application:
             else:
                 self.screen.capture_stop()
                 self.screen.print(b"\r\n*** Screen capture stopped ***\r\n")
+        elif c == 'h':
+            self.console_help()
         elif c == 'i':
             self.target_info()
         elif c == 'm':
@@ -157,6 +159,25 @@ class Application:
             server.toggle_timestamps()
         elif c == 'u':
             server.usb_toggle(1)
+
+    def console_help(self):
+        server = self.client()
+        server.console_print(
+            "\r\n*** Console help ***\r\n"
+            "  a: acquire target\r\n"
+            "  b: send console to pastebin\r\n"
+            "  c: toggle screen capture\r\n"
+            "  h: print this help message\r\n"
+            "  i: print target info\r\n"
+            "  m: switch between console and monitor\r\n"
+            "  p: toggle target on/off\r\n"
+            "  q: quit\r\n"
+            "  r: release target\r\n"
+            "  s: toggle storage between target/host\r\n"
+            "  t: toggle prefix console log with timestamp\r\n"
+            "  u: toggle usb device\r\n"
+            "\r\n"
+        )
 
     def console_pastebin(self):
         client = self.agent
@@ -419,7 +440,7 @@ class Application:
               socket.gethostname(), host.version, ""))
         print("Remote         : %s (%s)%30s\r" % (
               remote, remote_version, ""))
-        print(f"Prefix key:    : ctrl-{prefix_key}\r")
+        print(f"Prefix key:    : ctrl-{prefix_key} ('h' for help)\r")
         print(f"Session        : {session}\r")
         print("Target         : %-6s%s%s\r" % (tgt_status, locked, uptime))
         print("Storage on     : %-6s%s\r" % (storage_status, locked))

--- a/mtda/client.py
+++ b/mtda/client.py
@@ -93,7 +93,7 @@ class Client:
         return self._agent.console_remote(host, screen)
 
     def console_toggle(self):
-        return self._agent.console_toggle(self._session)
+        return self._agent.console_toggle(session=self._session)
 
     def debug(self, level, msg):
         if self._agent:
@@ -287,7 +287,7 @@ class Client:
     def target_lock(self, retries=0):
         status = False
         while status is False:
-            status = self._impl.target_lock(self._session)
+            status = self._impl.target_lock(session=self._session)
             if retries <= 0 or status is True:
                 break
             retries = retries - 1


### PR DESCRIPTION
While doing so, I noticed that many commands are broken. For `console_toggle` and `target_lock` the fix is trivial, but for the others (like `storage_swap`) it needs to be fixed in the attr-injector. I'm anyways wondering if the session should be manually injected or if the attr-injector should handle this.