### PR TITLE
Integrate swupdate with WFX

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -151,6 +151,10 @@ Files: mtda/share/nginx-multi-mtda.conf
 Copyright: 2023 Siemens AG
 License: MIT
 
+Files: meta-isar-extra/recipes-conf/swupdate-config-wfx/files/wfx.conf.tmpl
+Copyright: 2025 Siemens AG
+License: MIT
+
 Files: patches/cip-core/*
 Copyright: 2025 Siemens AG
 License: MIT

--- a/meta-isar-extra/conf/machine/abrootfs-common.inc
+++ b/meta-isar-extra/conf/machine/abrootfs-common.inc
@@ -14,6 +14,12 @@ INITRAMFS_INSTALL += " \
 IMAGE_TYPEDEP:wic += "squashfs"
 IMAGE_FSTYPES += "swu"
 
+# list of compatible hardware revisions
+SWU_HW_COMPAT ?= "mtda-${MACHINE}"
+# the hardware revision of the current machine
+MACHINE_HW_VERSION ?= "mtda-${MACHINE}"
+IMAGE_INSTALL += "swupdate-config-${MACHINE}"
+
 # the squashfs is already compressed. Do not compress externally
 SWU_COMPRESSION_TYPE = ""
 # compress the initrd with zstd to speedup decompression

--- a/meta-isar-extra/recipes-conf/swupdate-config-wfx/files/wfx.conf.tmpl
+++ b/meta-isar-extra/recipes-conf/swupdate-config-wfx/files/wfx.conf.tmpl
@@ -1,0 +1,1 @@
+SWUPDATE_SURICATTA_ARGS="--server lua -t ${WFX_TENANT} -u ${WFX_SERVER}/api/wfx/v1 -i $(cat /etc/machine-id)"

--- a/meta-isar-extra/recipes-conf/swupdate-config-wfx/swupdate-config-wfx_0.1.bb
+++ b/meta-isar-extra/recipes-conf/swupdate-config-wfx/swupdate-config-wfx_0.1.bb
@@ -1,0 +1,24 @@
+# This Isar layer is part of MTDA
+# Copyright (C) 2025 Siemens AG
+# SPDX-License-Identifier: MIT
+
+DESCRIPTION = "WFX backend configuration for swupdate"
+MAINTAINER = "mtda-users <mtda-users@googlegroups.com>"
+
+WFX_TENANT ??= "default"
+WFX_SERVER ??= "http://localhost:8080"
+
+SRC_URI = "file://wfx.conf.tmpl"
+
+TEMPLATE_FILES += "wfx.conf.tmpl"
+TEMPLATE_VARS += " \
+    WFX_SERVER \
+    WFX_TENANT \
+"
+
+inherit dpkg-raw
+
+do_install() {
+    install -d ${D}/etc/swupdate/conf.d
+    install -m 0644 ${WORKDIR}/wfx.conf ${D}/etc/swupdate/conf.d/wfx.conf
+}

--- a/meta-isar-extra/recipes-core/images/mtda-image-immutable.bb
+++ b/meta-isar-extra/recipes-core/images/mtda-image-immutable.bb
@@ -13,3 +13,6 @@ require recipes-core/images/mtda-image.bb
 
 # get a hostname via DHCP
 IMAGE_INSTALL:remove = "mtda-hostname"
+
+# register with WFX backend
+IMAGE_INSTALL += "swupdate-config-wfx"


### PR DESCRIPTION
We add a swupdate configuration to update the device with one of the DAU workflows from WFX. The WFX server can be specified with the WFX_SERVER bitbake variable (e.g. via a kas local config) and defaults to http://localhost:8080. By that, local tests with a SSH reverse forward can be done.

Once we have the general A/B rootfs image documented, we should also add example snippets to run the WFX workflow. But that's really just the example from https://siemens.github.io/wfx/docs/workflows/dau/