### PR TITLE
fix: add kwargs to toggle_timestamps method

### DIFF
--- a/mtda/main.py
+++ b/mtda/main.py
@@ -1039,7 +1039,8 @@ class MultiTenantDeviceAccess:
         return result
 
     @Pyro4.expose
-    def toggle_timestamps(self):
+    def toggle_timestamps(self, **kwargs):
+        # kwargs: might be called with session parameter
         self.mtda.debug(3, "main.toggle_timestamps()")
 
         if self.console_logger is not None:


### PR DESCRIPTION
This method is called with the auto-injected session parameter. While the session is irrelevant for this function, we must be interface compatible.

Fixes: fae44dc ("refactor(client): use dynamic wrappers for remote ...")