### PR TITLE
fix: use correct wks file on rpi4b-efi target

### DIFF
--- a/meta-isar/conf/machine/rpi4b-efi.inc
+++ b/meta-isar/conf/machine/rpi4b-efi.inc
@@ -9,8 +9,8 @@ DISTRO_ARCH ?= "arm64"
 
 KERNEL_NAME ?= "arm64"
 
-IMAGE_FSTYPES ??= "wic"
-WKS_FILE ??= "rpi4b-efi.wks"
+IMAGE_FSTYPES ?= "wic"
+WKS_FILE ?= "rpi4b-efi.wks"
 
 IMAGER_BUILD_DEPS = "u-boot-config-rpi4b"
 IMAGER_INSTALL:wic += "${IMAGER_BUILD_DEPS}"


### PR DESCRIPTION
We cannot define the WKS_FILE and IMAGE_FSTYPES as extra weak variables as isar/meta/classes/imagetypes_wic.bbclass also has an extra weak define which is loaded earlier. To fix this, we switch to weak defines.

Fixes: 46b2f6a ("refactor(rpi4): carve out common efi firmware part")