### PR TITLE
fix(image): correctly handle range end with overlap

### DIFF
--- a/mtda/storage/helpers/image.py
+++ b/mtda/storage/helpers/image.py
@@ -397,12 +397,11 @@ class Image(StorageController):
                              (cur_range["first"] - writtenBlocks)
                              * blksize - self.overlap)
                 self.handle.seek(nbytes, io.SEEK_CUR)
-            self.overlap -= min(self.overlap, nbytes)
             self.writtenBytes += nbytes
+            self.overlap = self.writtenBytes % blksize
             offset += nbytes
             remaining -= nbytes
 
-        self.overlap = self.writtenBytes % blksize
         return offset
 
     def _validate_and_reset_range(self):


### PR DESCRIPTION
There was a subtle blug in our implementation of the bmap algorithm: When ending a range but still carying an overlap (a not fully written block), the next overlap is computed was computed incorrectly. By that, the writing position shifted by [0-blocksize) bytes which lead to incorrectly written data blocks. This was detected by a checksum mismatch.

We fix this by further simplifying the algorithm: Instead of computing the overlap based on a delta, we simply compute it by taking "writtenBytes % blocksize". We did this anyway in case the current input was fully processed, now we also do it within the block writing logic.

Xref: #476 (failure is still not reported, but the bug in writing is fixed).

Please review carefully and also test on some files.