### PR TITLE
client: check if image is fully written

### DIFF
--- a/mtda/client.py
+++ b/mtda/client.py
@@ -346,6 +346,8 @@ class ImageFile:
             time.sleep(0.5)
         self._socket.close()
         self._socket = None
+        if outputsize and written != outputsize:
+            raise IOError(f'image write failed: wrote {written} out of {outputsize} bytes')
 
     def path(self):
         return self._path


### PR DESCRIPTION
In case the storage write is interrupted (e.g. because of a checksum mismatch or another internal error), we need to inform the other side about the issue.

As the current architecture does not provide an easy mechanism to inform about this, we just check if the written bytes are equal to the expected ones (in case we know about the full size.

Closes: #476