### PR TITLE
fix(packages): linux-image-* from bpo now depends on linux-base

### DIFF
--- a/meta-isar/conf/distro/preferences.mtda-bookworm-backports.conf
+++ b/meta-isar/conf/distro/preferences.mtda-bookworm-backports.conf
@@ -13,3 +13,7 @@ Pin-Priority: 501
 Package: firmware-brcm80211
 Pin: release n=bookworm-backports
 Pin-Priority: 501
+
+Package: linux-base
+Pin: release n=bookworm-backports
+Pin-Priority: 501


### PR DESCRIPTION
linux-image-* packages from -backports depend on linux-base >= 4.12 while bookworm ships 4.9. Let us pull linux-base from -backports for dependencies to be met.

Fixes: 1d3c93a