### PR TITLE
fix(keyboard): fix space key issue in www

### DIFF
--- a/mtda-www
+++ b/mtda-www
@@ -117,7 +117,8 @@ class KeyboardInputHandler(BaseHandler):
             "\b": "<backspace>", "    ": "<tab>", "caps": "<capslock>",
             "\n": "<enter>",
             "left": "<left>", "right": "<right>",
-            "up": "<up>", "down": "<down>"
+            "up": "<up>", "down": "<down>",
+            "<space>": " "
         }
 
         if input_key in key_map:

--- a/mtda/templates/index.html
+++ b/mtda/templates/index.html
@@ -158,6 +158,7 @@ SPDX-License-Identifier: MIT
         "Tab": "<tab>",
         "CapsLock": "<capslock>",
         "Enter": "<enter>",
+        " ": "<space>",
         "ArrowLeft": "<left>", "ArrowRight": "<right>",
         "ArrowUp": "<up>", "ArrowDown": "<down>"
         };


### PR DESCRIPTION
Physical Keyboard Failed to send the space in mtda-www. Added fix to send the modified strings for space and added downstream API to handle space. Before the change downstream API was unable to detect space and was sending empty string.