### PR TITLE
fix(www): check if the video window is focused to process keydown events

### DIFF
--- a/mtda/templates/index.html
+++ b/mtda/templates/index.html
@@ -456,6 +456,11 @@ SPDX-License-Identifier: MIT
     <script src="./assets/keysight.js"></script>
     <script type=text/javascript>
       window.addEventListener("keydown", function(event) {
+        // check if the video window is active or ignore keydown event
+        if (!videoWindow || !videoWindow.focused) {
+          // do nothing
+        }
+
         var key = keysight(event)
         const specialKeys = {
         "Escape": "<esc>",


### PR DESCRIPTION
As we may have multiple windows opened (console, python, video), we want key presses to be sent to the Device Under Test only when the video window is focused.