### PR TITLE
perf(pytest): make Console.wait_for() sleep after checking for matches

### DIFF
--- a/mtda/assets/www.py
+++ b/mtda/assets/www.py
@@ -157,7 +157,6 @@ class Console:
             exp_list.append(re.compile(expr))
 
         while timeout > 0:
-            await asyncio.sleep(intervals)
             if flush is True:
                 contents += await Console.flush()
             else:
@@ -173,6 +172,7 @@ class Console:
                     break
             if result is not None:
                 break
+            await asyncio.sleep(intervals)
             timeout -= intervals
         return result
 

--- a/mtda/pytest.py
+++ b/mtda/pytest.py
@@ -138,7 +138,6 @@ class Console:
             exp_list.append(re.compile(expr))
 
         while timeout > 0:
-            time.sleep(intervals)
             if flush is True:
                 contents += pytest.mtda.console_flush()
             else:
@@ -154,6 +153,7 @@ class Console:
                     break
             if result is not None:
                 break
+            time.sleep(intervals)
             timeout -= intervals
         return result
 


### PR DESCRIPTION
Console.wait_for() would sleep before checking for matches or errors: this is not necessary and should be done at the end of the retry loop