### PR TITLE
fix(www): use socket.send for input into the console

### DIFF
--- a/mtda/templates/index.html
+++ b/mtda/templates/index.html
@@ -616,7 +616,9 @@ SPDX-License-Identifier: MIT
       term.open(document.getElementById("console"));
       termfit.fit();
       term.onData((data) => {
-        socket.emit("console-input", { input: data });
+        socket.send(JSON.stringify({
+          "console-input": { input: data }
+        }));
       });
       consoleWindow.onresize = function(w, h) {
         termfit.fit()


### PR DESCRIPTION
socket.emit() only exists for socket.io (was removed with 5bf7a48): we should therefore use socket.send() for our native WebSocket

Fixes: 5bf7a48