### PR TITLE
fix(kas): debian/bookworm-base should not include common/base

### DIFF
--- a/kas/ci/fast.yml
+++ b/kas/ci/fast.yml
@@ -10,10 +10,12 @@
 # ---------------------------------------------------------------------------
 
 build_system: isar
+machine: qemuamd64
 
 header:
   version: 17
   includes:
+    - kas/common/base.yml
     - kas/debian/bookworm-base.yml
 
 target:

--- a/kas/ci/full.yml
+++ b/kas/ci/full.yml
@@ -1,5 +1,5 @@
 # ---------------------------------------------------------------------------
-# Debian image to run MTDA on NanoPI variants
+# Build Debian images for bookworm
 # ---------------------------------------------------------------------------
 #
 # This software is a part of MTDA.
@@ -10,10 +10,12 @@
 # ---------------------------------------------------------------------------
 
 build_system: isar
+machine: qemuamd64
 
 header:
   version: 17
   includes:
+    - kas/common/base.yml
     - kas/debian/bookworm-base.yml
 
 target:

--- a/kas/common/base.yml
+++ b/kas/common/base.yml
@@ -12,7 +12,6 @@
 header:
   version: 17
 
-machine: qemuamd64
 target: mtda-image
 
 repos:

--- a/kas/debian/bookworm-base.yml
+++ b/kas/debian/bookworm-base.yml
@@ -11,7 +11,9 @@
 
 header:
   version: 17
-  includes:
-    - kas/common/base.yml
 
 distro: mtda-bookworm
+
+bblayers_conf_header:
+  distro-override: |
+    DISTRO:forcevariable = "mtda-bookworm"

--- a/kas/debian/mtda-beaglebone-black.yml
+++ b/kas/debian/mtda-beaglebone-black.yml
@@ -15,4 +15,5 @@ machine: beaglebone-black
 header:
   version: 17
   includes:
+    - kas/common/base.yml
     - kas/debian/bookworm-base.yml

--- a/kas/debian/mtda-nanopi-neo-ebg.yml
+++ b/kas/debian/mtda-nanopi-neo-ebg.yml
@@ -15,5 +15,6 @@ machine: nanopi-neo-ebg
 header:
   version: 17
   includes:
+    - kas/common/base.yml
     - kas/debian/bookworm-base.yml
     - kas/opt/ab-rootfs.yml

--- a/kas/debian/mtda-nanopi-neo.yml
+++ b/kas/debian/mtda-nanopi-neo.yml
@@ -15,4 +15,5 @@ machine: nanopi-neo
 header:
   version: 17
   includes:
+    - kas/common/base.yml
     - kas/debian/bookworm-base.yml

--- a/kas/debian/mtda-qemu-amd64-ebg.yml
+++ b/kas/debian/mtda-qemu-amd64-ebg.yml
@@ -15,5 +15,6 @@ machine: qemuamd64-ebg
 header:
   version: 17
   includes:
+    - kas/common/base.yml
     - kas/debian/bookworm-base.yml
     - kas/opt/ab-rootfs.yml

--- a/kas/debian/mtda-qemu-amd64.yml
+++ b/kas/debian/mtda-qemu-amd64.yml
@@ -15,4 +15,5 @@ machine: qemuamd64
 header:
   version: 17
   includes:
+    - kas/common/base.yml
     - kas/debian/bookworm-base.yml

--- a/kas/debian/mtda-rpi4b-ebg.yml
+++ b/kas/debian/mtda-rpi4b-ebg.yml
@@ -15,5 +15,6 @@ machine: rpi4b-ebg
 header:
   version: 17
   includes:
+    - kas/common/base.yml
     - kas/debian/bookworm-base.yml
     - kas/opt/ab-rootfs.yml

--- a/kas/debian/mtda-rpi4b-efi.yml
+++ b/kas/debian/mtda-rpi4b-efi.yml
@@ -15,4 +15,5 @@ machine: rpi4b-efi
 header:
   version: 17
   includes:
+    - kas/common/base.yml
     - kas/debian/bookworm-base.yml

--- a/kas/debian/mtda-rpi4b.yml
+++ b/kas/debian/mtda-rpi4b.yml
@@ -15,4 +15,5 @@ machine: rpi4b
 header:
   version: 17
   includes:
+    - kas/common/base.yml
     - kas/debian/bookworm-base.yml


### PR DESCRIPTION
The config/base fragment defines a default target. That was fine until we wanted to build using

     kas/debian/mtda-rpi4b-ebg.yml:kas/debian/trixie-base.yml

The debian/trixie-base fragment would override the non-default target "mtda-immutable-image" but that change would be lost with debian/trixie-base since it would include again common/base.

Targets should include both common/base and debian/*-base

Suggested-by: Felix Moessbauer <felix.moessbauer@siemens.com>