### PR TITLE
fix(abrootfs): assign stable uid / gid for mtda

### DIFF
--- a/meta-isar/recipes-core/images/mtda-image.bb
+++ b/meta-isar/recipes-core/images/mtda-image.bb
@@ -71,8 +71,12 @@ IMAGE_INSTALL:append = " expand-on-first-boot "
 IMAGE_PREINSTALL:append = " zstd"
 
 # Create a "mtda" user account with "mtda" as the default password
-USERS += "mtda"
+# For ab-rootfs update, we assign a stable uid/gid
 GROUPS += "mtda"
+GROUP_mtda[gid] = "1001"
+
+USERS += "mtda"
+USER_mtda[uid] = "1001"
 USER_mtda[gid] = "mtda"
 USER_mtda[home] = "/home/mtda"
 USER_mtda[comment] = "Multi-Tenant Device Access"


### PR DESCRIPTION
We currently do not assign a stable uid / gid for the mtda user / group. By that, each install might get a different one. In case of abrootfs, we need stable assignments, as the ids need to be stable across multiple rootfs creations, as persisted data (like the homedir and mtda managed files) otherwise cannot be accessed after an update.

Fixes: 04ad2d5 ("feat: add a/b updatable image")