### PR TITLE
ci: remove build/tmp/work after each build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,18 +51,22 @@ jobs:
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/v')
         run: |
           ./kas-container build kas/ci/fast.yml
+          sudo rm -rf --one-file-system build/tmp/work
       - name: Build Full CI targets for bookworm
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
         run: |
           ./kas-container build kas/ci/full-bookworm.yml
+          sudo rm -rf --one-file-system build/tmp/work
       - name: Build Full CI targets for trixie
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
         run: |
           ./kas-container build kas/ci/full-trixie.yml
+          sudo rm -rf --one-file-system build/tmp/work
       - name: Build Full CI targets for noble
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
         run: |
           ./kas-container build kas/ci/full-noble.yml
+          sudo rm -rf --one-file-system build/tmp/work
       - name: Upload NanoPI images
         uses: actions/upload-artifact@v4
         if: startsWith(github.ref, 'refs/tags/v')

--- a/scripts/build-using-ppa
+++ b/scripts/build-using-ppa
@@ -11,7 +11,7 @@
 # ---------------------------------------------------------------------------
 
 build_dir=${1:-build}
-distro=${2:-jammy}
+distro=${2:-noble}
 signer=${3:-D26CC6417E10F45C61C83B38FA5C9FECC03529BF}
 tmp_dir=""
 
@@ -56,7 +56,7 @@ allow_unsigned_uploads = 0
 EOF
 
 build_dir=$(readlink -f ${build_dir})
-for p in $(find ${build_dir}/tmp/work/ubuntu-${distro}-* -maxdepth 5 -name '*.dsc')
+for p in $(find ${build_dir}/tmp/deploy/isar-apt/ubuntu-${distro}-*/apt -maxdepth 6 -name '*.dsc')
 do
     dir=$(dirname ${p})
     name=$(basename ${p})


### PR DESCRIPTION
reduce our storage requirements for our CI builds by removing build/tmp/work after each build. We however keep build/tmp/deploy for artefacts we may want to archive.