### PR TITLE
refactor(storage): report actual bytes written and seeked (vs position)

### DIFF
--- a/mtda/main.py
+++ b/mtda/main.py
@@ -1812,9 +1812,9 @@ class MultiTenantDeviceAccess:
         self.mtda.debug(4, f"main.notify: {result}")
         return result
 
-    def notify_write(self):
+    def notify_write(self, size=0):
         if self._writer:
-            self._writer.notify_write()
+            self._writer.notify_write(size=size)
 
     def start(self):
         self.mtda.debug(3, "main.start()")

--- a/mtda/storage/docker.py
+++ b/mtda/storage/docker.py
@@ -93,7 +93,7 @@ class DockerController(StorageController):
             if self._handle is not None:
                 result = self._handle.write(data)
 
-        self.mtda.notify_write()
+        self.mtda.notify_write(size=len(data))
         self.mtda.debug(3, f"storage.docker.write(): {result}")
         return result
 

--- a/mtda/storage/helpers/image.py
+++ b/mtda/storage/helpers/image.py
@@ -324,8 +324,8 @@ class Image(StorageController):
                 else:
                     # No bmap
                     result = self.handle.write(data)
+                    self.mtda.notify_write(size=len(data))
 
-        self.mtda.notify_write()
         self.mtda.debug(3, f"storage.helpers.image.write(): {str(result)}")
         return result
 
@@ -361,6 +361,7 @@ class Image(StorageController):
             self.overlap = self.writtenBytes % blksize
             offset += nbytes
             remaining -= nbytes
+            self.mtda.notify_write(size=nbytes)
 
         return offset
 
@@ -382,4 +383,5 @@ class Image(StorageController):
     def _write_with_chksum(self, data):
         if self.rangeChkSum:
             self.rangeChkSum.update(data)
-        return self.handle.write(data)
+        result = self.handle.write(data)
+        return result


### PR DESCRIPTION
Writes are not guaranteed to be sequential with bmap, we should therefore report bytes that were written to the storage instead of the position within the storage.

[Felix: also account seeks into writes to fullfill written==size assertion on client side. Downgrade to refactoring]

Suggested by: Felix Moessbauer <felix.moessbauer@siemens.com>