### PR TITLE
fix(configs): use /usr/share/ovmf/OVMF.fd for bookworm and trixie

### DIFF
--- a/configs/qemu.ini
+++ b/configs/qemu.ini
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------------------------
 #
 # This software is a part of MTDA.
-# Copyright (C) 2021 Siemens Digital Industries Software
+# Copyright (C) 2025 Siemens AG
 #
 # ---------------------------------------------------------------------------
 # SPDX-License-Identifier: MIT
@@ -44,7 +44,7 @@ cpu=host
 smp=0
 machine=pc
 memory=2048
-pflash_ro=/usr/share/OVMF/OVMF_CODE.fd
+pflash_ro=/usr/share/ovmf/OVMF.fd
 pflash_rw=/var/lib/mtda/qemu-ovmf-vars.fd
 storage.0=/var/lib/mtda/ssd.img
 storage.0.size=16


### PR DESCRIPTION
Use /usr/share/ovmf/OVMF.fd since found in both bookworm and trixie while /usr/share/OVMF/OVMF_CODE.fd only exists in bookworm.