### PR TITLE
feat(qemu): add mtda-cli firmware command to switch boot firmware

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -92,6 +92,7 @@ netmask
 nmcli
 Numbat
 OTG
+OVMF
 pastebin
 pdu
 php
@@ -102,6 +103,8 @@ prebuilt
 programmatically
 pytest
 qemu
+QEMU
+QEMU's
 rc
 RFB
 RJ
@@ -111,6 +114,7 @@ rst
 samsung
 SBC
 sbabic
+SeaBIOS
 sdmux
 SDmux
 SDMux

--- a/configs/qemu.ini
+++ b/configs/qemu.ini
@@ -44,14 +44,30 @@ cpu=host
 smp=0
 machine=pc
 memory=2048
-pflash_ro=/usr/share/ovmf/OVMF.fd
-pflash_rw=/var/lib/mtda/qemu-ovmf-vars.fd
 storage.0=/var/lib/mtda/ssd.img
 storage.0.size=16
 #storage.1=/var/lib/mtda/extra-ssd.img
 #storage.1.size=16
 watchdog=i6300esb
 #uuid=11111111-2222-3333-4444-555555555555
+
+# ---------------------------------------------------------------------------
+# Boot firmware settings ("mtda-cli firmware efi|legacy" to switch, qemu
+# power controller only). The active mode is remembered across restarts of
+# the mtda-agent in /var/lib/mtda/qemu-firmware. Until a mode has been
+# selected at least once, "default" below picks the starting mode (defaults
+# to "efi" itself if omitted). Legacy (SeaBIOS) boot needs no section at all
+# unless a custom BIOS image should be used instead of QEMU's built-in one.
+# ---------------------------------------------------------------------------
+#[firmware]
+#default=efi
+
+[efi]
+pflash_ro=/usr/share/ovmf/OVMF.fd
+pflash_rw=/var/lib/mtda/qemu-ovmf-vars.fd
+
+[legacy]
+#bios=/usr/share/seabios/bios.bin
 
 # ---------------------------------------------------------------------------
 # Shared Storage settings

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -324,7 +324,9 @@ The ``qemu`` driver may be used to use QEMU/KVM instead of a physical device.
 The following settings are supported:
 
 * ``bios``: string [optional]
-    The BIOS to be loaded by QEMU/KVM.
+    The BIOS to be loaded by QEMU/KVM. Prefer a ``[legacy]`` section (see
+    below) if the boot firmware should be switchable with ``mtda-cli
+    firmware``.
 
 * ``cpu``: string [optional]
     The CPU to be emulated by QEMU/KVM.
@@ -349,10 +351,12 @@ The following settings are supported:
     512 MiB).
 
 * ``pflash_ro``: string [optional]
-    Path to the read-only firmware flash.
+    Path to the read-only firmware flash. Prefer an ``[efi]`` section (see
+    below) if the boot firmware should be switchable with ``mtda-cli
+    firmware``.
 
 * ``pflash_rw``: string [optional]
-    Path to the read-write firmware flash.
+    Path to the read-write firmware flash. See ``pflash_ro`` above.
 
 * ``storage``: string [optional]
     Path to the emulated machine storage. Use ``storage.0``, ``storage.1``,
@@ -376,6 +380,49 @@ The following settings are supported:
 
 * ``watchdog``: string [optional]
     Name of the watchdog driver provided by QEMU/KVM for the selected machine.
+
+``[firmware]``, ``[efi]`` and ``[legacy]`` sections
+""""""""""""""""""""""""""""""""""""""""""""""""""
+
+These optional top-level sections let the boot firmware be switched at
+runtime with ``mtda-cli firmware efi|legacy`` (querying the current mode
+with no argument works too). The selected mode is persisted across
+mtda-agent restarts in ``/var/lib/mtda/qemu-firmware`` and applied the next
+time QEMU is started; if the target is already powered on when switching,
+``mtda-cli firmware`` restarts it automatically. This command returns "not
+supported" for power controllers other than ``qemu``.
+
+* ``[firmware]`` section:
+
+  * ``default``: ``efi`` or ``legacy`` [optional]
+      Starting firmware mode, used only until a mode has been selected at
+      least once via ``mtda-cli firmware`` (afterwards the persisted state
+      in ``/var/lib/mtda/qemu-firmware`` wins). Defaults to ``efi`` if
+      omitted, unless only ``[legacy]`` is configured. Setting this to
+      ``efi`` requires an ``[efi]`` section (or the legacy flat
+      ``pflash_ro``/``pflash_rw`` keys) to also be configured.
+
+* ``[efi]`` section:
+
+  * ``pflash_ro``: string [required to select ``efi``]
+      Path to the read-only OVMF firmware flash (e.g.
+      ``/usr/share/OVMF/OVMF_CODE_4M.fd``).
+
+  * ``pflash_rw``: string [optional]
+      Path to the read-write OVMF variable store. Created automatically if
+      it does not exist yet.
+
+* ``[legacy]`` section:
+
+  * ``bios``: string [optional]
+      Path to a custom legacy BIOS image. May be omitted entirely — an
+      empty (or absent) ``[legacy]`` section selects QEMU's built-in SeaBIOS.
+
+For backward compatibility, a config using the flat ``pflash_ro``/
+``pflash_rw``/``bios`` keys directly under ``[power]`` (without ``[efi]``/
+``[legacy]`` sections) still works: ``mtda-cli firmware`` reports the fixed
+mode implied by those keys, but switching to the other mode requires adding
+the corresponding section.
 
 ``shellcmd`` driver settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mtda-cli
+++ b/mtda-cli
@@ -544,6 +544,12 @@ class Application:
         print(f"Prefix key:    : ctrl-{prefix_key} ('h' for help)\r")
         print(f"Session        : {session}\r")
         print("Target         : %-6s%s%s\r" % (tgt_status, locked, uptime))
+        try:
+            firmware = client.target_firmware()
+        except Exception:
+            firmware = None
+        if firmware is not None:
+            print(f"Firmware       : {firmware}\r")
         print("Storage on     : %-6s%s\r" % (storage_status, locked))
         print(f"Storage writes : {written} ({writing})\r")
 
@@ -585,6 +591,16 @@ class Application:
     def target_uptime_cmd(self, args=None):
         uptime = self.target_uptime()
         print(uptime)
+        return 0
+
+    def firmware_cmd(self, args=None):
+        mode = getattr(args, "mode", None)
+        try:
+            result = self.client().target_firmware(mode)
+        except Exception as e:
+            print(str(e), file=sys.stderr)
+            return 1
+        print(result)
         return 0
 
     def target_cmd(self, args):
@@ -757,6 +773,18 @@ class Application:
         )
         s.add_argument("wait_string", type=str, help="String to wait")
         s.add_argument("timeout", type=int, nargs="?", help="Timeout")
+
+        # subcommand: firmware
+        cmd = self.firmware_cmd
+        p = subparsers.add_parser(
+            "firmware",
+            help="Get or set the boot firmware (qemu power controller only)",
+        )
+        p.add_argument(
+            "mode", type=str, nargs="?", choices=["efi", "legacy"],
+            help="Firmware mode to switch to"
+        )
+        p.set_defaults(func=cmd)
 
         # subcommand: getenv
         cmd = self.getenv_cmd

--- a/mtda/client.py
+++ b/mtda/client.py
@@ -252,6 +252,12 @@ class _GrpcImpl:
 
     # --- Target ---
 
+    def target_firmware(self, mode=None, **kwargs):
+        req = mtda_pb2.TargetFirmwareRequest(
+            mode=mode or '', get_only=(mode is None))
+        r = self._call(self._stub.TargetFirmware, req)
+        return r.value if r.has_value else None
+
     def target_lock(self, **kwargs):
         return self._call(self._stub.TargetLock, mtda_pb2.Empty()).value
 

--- a/mtda/console/qemu.py
+++ b/mtda/console/qemu.py
@@ -57,6 +57,10 @@ class QemuConsole(ConsoleInterface):
         self.mtda.debug(3, "console.qemu.close()")
 
         result = True
+        if self.opened is True:
+            self.tx.close()
+            self.rx.close()
+            self.opened = False
 
         self.mtda.debug(3, f"console.qemu.close(): {str(result)}")
         return result

--- a/mtda/grpc/mtda.proto
+++ b/mtda/grpc/mtda.proto
@@ -231,6 +231,11 @@ message StorageToggleResponse {
 // Target / power
 // ---------------------------------------------------------------------------
 
+message TargetFirmwareRequest {
+    string mode     = 1;   // "efi" or "legacy"; ignored when get_only is true
+    bool   get_only = 2;
+}
+
 message TargetStatusResponse {
     string status = 1;
 }
@@ -354,6 +359,7 @@ service MtdaService {
     rpc StorageWrite       (stream StorageChunkRequest) returns (StorageWriteResponse);
 
     // --- Target ---
+    rpc TargetFirmware     (TargetFirmwareRequest)   returns (StringResponse);
     rpc TargetLock         (Empty)                   returns (BoolResponse);
     rpc TargetLocked       (Empty)                   returns (BoolResponse);
     rpc TargetOff          (Empty)                   returns (BoolResponse);

--- a/mtda/grpc/servicer.py
+++ b/mtda/grpc/servicer.py
@@ -436,6 +436,14 @@ class MtdaServicer(mtda_pb2_grpc.MtdaServiceServicer):
     # Target / power
     # ------------------------------------------------------------------
 
+    def TargetFirmware(self, request, context):
+        try:
+            mode = None if request.get_only else request.mode
+            return _str_response(
+                self._agent.target_firmware(mode, session=_session(context)))
+        except Exception as e:
+            context.abort(grpc.StatusCode.INTERNAL, str(e))
+
     def TargetLock(self, request, context):
         try:
             return _bool_response(

--- a/mtda/main.py
+++ b/mtda/main.py
@@ -1440,6 +1440,23 @@ class MultiTenantDeviceAccess:
         self.mtda.debug(3, f"main.target_status(): {result}")
         return result
 
+    def target_firmware(self, mode=None, **kwargs):
+        self.mtda.debug(3, "main.target_firmware()")
+
+        session = kwargs.get("session", None)
+        self.session_ping(session)
+        if self.power is None or not hasattr(self.power, 'firmware'):
+            variant = self.power.variant if self.power is not None else "none"
+            raise NotImplementedError(
+                f'firmware is not supported for {variant}')
+        if mode is not None and self.power_locked(session):
+            raise RuntimeError('cannot change firmware, target is locked!')
+        with self._power_lock:
+            result = self.power.firmware(mode)
+
+        self.mtda.debug(3, f"main.target_firmware(): {result}")
+        return result
+
     def target_toggle(self, **kwargs):
         self.mtda.debug(3, "main.target_toggle()")
 
@@ -1750,6 +1767,12 @@ class MultiTenantDeviceAccess:
 
         import atexit
         atexit.register(self.storage_close)
+
+    def post_configure_power(self, power, config, parser):
+        self.mtda.debug(3, "main.post_configure_power()")
+
+        if hasattr(power, 'configure_firmware'):
+            power.configure_firmware(parser)
 
     def load_remote_config(self, parser):
         self.mtda.debug(3, "main.load_remote_config()")

--- a/mtda/power/qemu.py
+++ b/mtda/power/qemu.py
@@ -40,8 +40,14 @@ class QemuController(PowerController):
         self.cpu = None
         self.smp = None
         self.drives = []
+        self.efi_conf = {}
+        self.usb_bootindex = 100
         self.executable = "kvm"
+        self.firmware_state_file = "/var/lib/mtda/qemu-firmware"
         self.hostname = "mtda-kvm"
+        self.legacy_conf = {}
+        # re-entrant: usb_add()/usb_rm() hold the lock across several
+        # qmp() calls, and qmp() itself locks
         self.lock = threading.RLock()
         self.machine = None
         self.memory = Size.to_bytes(512, 'MiB')
@@ -49,6 +55,7 @@ class QemuController(PowerController):
         self.novnc = "/usr/share/novnc"
         self.pflash_ro = None
         self.pflash_rw = None
+        self.firmware_mode = None
         self.pidOfQemu = None
         self.pidOfSwTpm = None
         self.pidOfWebsockify = None
@@ -116,6 +123,99 @@ class QemuController(PowerController):
             else:
                 break
 
+    def configure_firmware(self, parser):
+        self.mtda.debug(3, "power.qemu.configure_firmware()")
+
+        if parser.has_section('efi'):
+            self.efi_conf = dict(parser.items('efi'))
+        elif self.pflash_ro or self.pflash_rw:
+            # backward compat: flat pflash_ro/pflash_rw under [power]
+            self.efi_conf = {k: v for k, v in
+                             (('pflash_ro', self.pflash_ro),
+                              ('pflash_rw', self.pflash_rw)) if v}
+
+        if parser.has_section('legacy'):
+            self.legacy_conf = dict(parser.items('legacy'))
+        elif self.bios:
+            self.legacy_conf = {'bios': self.bios}
+
+        default = None
+        if parser.has_section('firmware'):
+            default = parser.get('firmware', 'default', fallback=None)
+            if default is not None and default not in ('efi', 'legacy'):
+                raise ValueError(f"unsupported firmware default: {default}")
+            if default == 'efi' and not self.efi_conf:
+                raise ValueError(
+                    "firmware default is 'efi' but no [efi] section "
+                    "(or pflash_ro/pflash_rw) is configured")
+        if default is None:
+            # default to efi unless only legacy is configured
+            default = 'legacy' if (self.legacy_conf and not self.efi_conf) \
+                else 'efi'
+
+        self.firmware_mode = self._load_firmware_state() or default
+        self._apply_firmware(self.firmware_mode)
+
+    def _load_firmware_state(self):
+        if os.path.exists(self.firmware_state_file):
+            with open(self.firmware_state_file, "r") as f:
+                mode = f.read().strip()
+                if mode in ('efi', 'legacy'):
+                    return mode
+        return None
+
+    def _apply_firmware(self, mode):
+        self.mtda.debug(3, f"power.qemu._apply_firmware({mode})")
+
+        if mode == 'efi':
+            conf = self.efi_conf
+            self.bios = None
+            ro = conf.get('pflash_ro')
+            rw = conf.get('pflash_rw')
+            self.pflash_ro = os.path.realpath(ro) if ro else None
+            self.pflash_rw = os.path.realpath(rw) if rw else None
+        else:
+            conf = self.legacy_conf
+            self.pflash_ro = None
+            self.pflash_rw = None
+            bios = conf.get('bios')
+            self.bios = os.path.realpath(bios) if bios else None
+
+    def firmware(self, mode=None):
+        self.mtda.debug(3, "power.qemu.firmware()")
+
+        if mode is not None and mode != self.firmware_mode:
+            if mode not in ('efi', 'legacy'):
+                raise ValueError(f"unsupported firmware mode: {mode}")
+            if mode == 'efi' and not self.efi_conf:
+                raise ValueError(
+                    "efi firmware is not configured (add an [efi] "
+                    "section with pflash_ro/pflash_rw)")
+            self.firmware_mode = mode
+            self._apply_firmware(mode)
+            os.makedirs("/var/lib/mtda", exist_ok=True)
+            with open(self.firmware_state_file, "w") as f:
+                f.write(mode + "\n")
+
+            # the new firmware only takes effect on the next qemu launch;
+            # restart it now if it is already running
+            if self.pidOfQemu is not None:
+                self.mtda.debug(2, "power.qemu.firmware(): "
+                                   f"restarting qemu for {mode} firmware")
+                # start() unlinks and recreates the serial pipes, so any
+                # console already attached to them needs to be closed and
+                # reopened around the restart or it's left reading/writing
+                # a stale (deleted) fifo
+                logger = self.mtda.console_logger
+                if logger is not None:
+                    logger.pause()
+                self.stop()
+                self.start()
+                if logger is not None:
+                    logger.resume()
+
+        return self.firmware_mode
+
     def probe(self):
         self.mtda.debug(3, "power.qemu.probe()")
 
@@ -156,6 +256,7 @@ class QemuController(PowerController):
 
         if self.pidOfQemu is not None:
             return True
+        self.usb_bootindex = 100
         if os.path.exists(self._qmp_socket):
             os.unlink(self._qmp_socket)
         if os.path.exists(self.serial_in):
@@ -178,6 +279,7 @@ class QemuController(PowerController):
         options += " -device usb-tablet"
         options += " -vga virtio"
         options += " -vnc :0,websocket=on"
+        options += " -boot menu=on,splash-time=5000"
 
         # extra options
         if self.bios is not None:
@@ -227,9 +329,15 @@ class QemuController(PowerController):
                                  "or is not a file and cannot be created: "
                                  "%s" % (self.pflash_rw, e))
         if len(self.drives) > 0:
-            for drv, size in self.drives:
+            for n, (drv, size) in enumerate(self.drives):
                 size = int(size / 1024**3)
-                options += f" -drive file={drv},media=disk,format=qcow2"
+                # bootindex can't be passed inline on a qcow2 -drive; split
+                # into a backend (if=none) and an explicit ide-hd frontend
+                # instead. Internal storage gets top priority (lowest index);
+                # user needs to pick the USB drive from the firmware to boot
+                # from it.
+                options += f" -drive if=none,id=hd{n},format=qcow2,file={drv}"
+                options += f" -device ide-hd,drive=hd{n},bootindex={n}"
                 if os.path.exists(drv) is True:
                     cmd = ['qemu-img', 'info', drv]
                     info = subprocess.check_output(cmd, encoding="utf-8")
@@ -338,17 +446,20 @@ class QemuController(PowerController):
         self._usb_devices.clear()
 
         if self.pidOfQemu is not None:
-            result = System.kill("qemu", self.pidOfQemu)
+            still_alive = System.kill("qemu", self.pidOfQemu)
+            result = not still_alive
             if result:
                 self.pidOfQemu = None
 
         if self.pidOfSwTpm is not None:
-            result = System.kill("swtpm", self.pidOfSwTpm)
+            still_alive = System.kill("swtpm", self.pidOfSwTpm)
+            result = not still_alive
             if result:
                 self.pidOfSwTpm = None
 
         if self.pidOfWebsockify is not None:
-            result = System.kill("websockify", self.pidOfWebsockify)
+            still_alive = System.kill("websockify", self.pidOfWebsockify)
+            result = not still_alive
             if result:
                 self.pidOfWebsockify = None
 
@@ -488,12 +599,18 @@ class QemuController(PowerController):
                         "id": id,
                         "drive": id,
                         "removable": True,
+                        "bootindex": self.usb_bootindex,
                     }) is not None
                     if added is False:
                         self.qmp("blockdev-del", {"node-name": id})
                 if added is True:
                     result = id
                     self._usb_devices.add(id)
+                    # hot-plugged devices need an explicit bootindex to be
+                    # added to the firmware boot order (SeaBIOS/OVMF both
+                    # read it from fw_cfg's bootorder, which is otherwise
+                    # only populated from devices present at qemu startup)
+                    self.usb_bootindex += 1
                     self.mtda.debug(2, "power.qemu.usb_add(): "
                                        "usb-storage '{0}' connected"
                                        .format(id))


### PR DESCRIPTION
Add "mtda-cli firmware [efi|legacy]" to query or switch the boot firmware used by the qemu power controller, between OVMF (EFI) and SeaBIOS (legacy). Querying with no argument returns the current mode; other power controllers report "not supported".

Config gains optional [efi] and [legacy] sections under [power] to point at OVMF pflash files or a custom legacy BIOS image; flat pflash_ro/pflash_rw/bios keys directly under [power] keep working for backward compatibility. The active mode is persisted across mtda-agent restarts in /var/lib/mtda/qemu-firmware and defaults to efi unless only [legacy] is configured (overridable via [firmware] default=). Switching modes while qemu is already running restarts the qemu process itself so the new firmware takes effect immediately.