### PR TITLE
feat(power/pduclient): support multiple PDU ports for multi-supply devices

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -314,8 +314,14 @@ of the device attached to MTDA. The following settings are supported:
 * ``hostname``: string [required]
     The PDU which will run power commands sent by the MTDA agent.
 
-* ``port``: integer [required]
-    The port on the specified PDU to which the device is connected.
+* ``port``: string [required]
+    Comma-separated list of ports on the specified PDU to which the device is connected.
+    Ports are powered on and off in the order listed.
+
+    Example::
+
+        port = 1
+        port = 1,2
 
 ``qemu`` driver settings
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mtda/power/pduclient.py
+++ b/mtda/power/pduclient.py
@@ -33,7 +33,7 @@ class PduClientPowerController(PowerController):
         if 'hostname' in conf:
             self.hostname = conf['hostname']
         if 'port' in conf:
-            self.port = conf['port']
+            self.port = [p.strip() for p in conf['port'].split(',')]
 
     def probe(self):
         if self.daemon is None:
@@ -41,34 +41,36 @@ class PduClientPowerController(PowerController):
                              "not specified ('daemon' not set)!")
         if self.hostname is None:
             raise ValueError("pdu not specified ('hostname' not set)!")
-        if self.port is None:
-            raise ValueError("port not specified!")
+        if not self.port:
+            raise ValueError("port(s) not specified ('port' not set)!")
 
-    def cmd(self, what):
+    def cmd(self, what, port):
         client = "/usr/bin/pduclient"
         return os.system(
             "{0} --daemon {1} --hostname {2} --command {3} "
             "--port {4}"
-            .format(client, self.daemon, self.hostname, what, self.port))
+            .format(client, self.daemon, self.hostname, what, port))
 
     def command(self, args):
         return False
 
     def on(self):
-        """ Power on the attached device"""
-        status = self.cmd('on')
-        if status == 0:
-            self.state = self.POWER_ON
-            return True
-        return False
+        """ Power on the attached device (all configured PDU ports)"""
+        for port in self.port:
+            status = self.cmd('on', port)
+            if status != 0:
+                return False
+        self.state = self.POWER_ON
+        return True
 
     def off(self):
-        """ Power off the attached device"""
-        status = self.cmd('off')
-        if status == 0:
-            self.state = self.POWER_OFF
-            return True
-        return False
+        """ Power off the attached device (all configured PDU ports)"""
+        for port in self.port:
+            status = self.cmd('off', port)
+            if status != 0:
+                return False
+        self.state = self.POWER_OFF
+        return True
 
     def status(self):
         """ Determine the current power state of the attached device"""


### PR DESCRIPTION
The pduclient driver previously supported only a single PDU port per device. Devices with auxiliary power inputs require multiple ports to be switched together.

- Add `port` config key accepting a comma-separated list of port numbers
- Power on/off ports in configured order