### PR TITLE
storage: report success from rollback and commit

### DIFF
--- a/mtda/storage/qemu.py
+++ b/mtda/storage/qemu.py
@@ -105,21 +105,23 @@ class QemuController(Image):
     def commit(self, ignore_missing=False):
         if self.cow is None:
             if ignore_missing:
-                return
+                return True
             raise MissingCowDeviceError('commit')
 
         cmd = ['qemu-img', 'commit', self.cow]
         subprocess.check_call(cmd)
+        return True
 
     def rollback(self, ignore_missing=False):
         if self.cow is None:
             if ignore_missing:
-                return
+                return True
             raise MissingCowDeviceError('rollback')
 
         cmd = ['qemu-img', 'create', '-F', 'raw', '-f', 'qcow2',
                '-b', self.file, self.cow, f'{self.size}M']
         subprocess.check_call(cmd)
+        return True
 
     def supports_hotplug(self):
         return True

--- a/mtda/storage/usbf.py
+++ b/mtda/storage/usbf.py
@@ -150,7 +150,7 @@ class UsbFunctionController(Image):
     def rollback(self, ignore_missing=False):
         if self.cow_device is None:
             if ignore_missing:
-                return
+                return True
             raise MissingCowDeviceError('rollback')
 
         subprocess.run(['/sbin/kpartx', '-dv', f"/dev/mapper/{DM_COW}"])
@@ -165,11 +165,12 @@ class UsbFunctionController(Image):
                f"0 {self.base_size} snapshot "
                f"{self.base_device} {self.cow_device} P 8"]
         subprocess.check_call(cmd)
+        return True
 
     def commit(self, ignore_missing=False):
         if self.cow_device is None:
             if ignore_missing:
-                return
+                return True
             raise MissingCowDeviceError('commit')
 
         # Trigger merge
@@ -222,6 +223,7 @@ class UsbFunctionController(Image):
                f"0 {self.base_size} snapshot "
                f"{self.base_device} {self.cow_device} P 8"]
         subprocess.check_call(cmd)
+        return True
 
     """ Get file used by the USB Function driver"""
     def probe(self):


### PR DESCRIPTION
Fixes #597.

`mtda-cli storage rollback` prints `could not rollback changes made to shared storage!` and exits non-zero after a rollback which did exactly what it was asked to, so the reporter has to write `|| :` around it.

**Where the false failure comes from**

```
usbf.rollback()                 no return statement          -> None
main.storage_rollback()         result = self.storage...     -> None
grpc/servicer._bool_response()  BoolResponse(value=bool(v))  -> False
mtda-cli storage_rollback()     if status is False           -> prints, exits 1
```

`bool(None)` is where it turns into a failure. The same applies to `commit`, and to both the usbf and qemu controllers.

**The fix**

`return True` on the paths that completed, and on the `ignore_missing` path where there was nothing to do.

This is not a new convention: every other storage method already returns a value.

| | rollback | commit | to_host | to_target | mount | open | close |
| --- | --- | --- | --- | --- | --- | --- | --- |
| before | **no** | **no** | yes | yes | yes | yes | yes |

I checked the other callers before changing the signature — `helpers/image.py:72`, `usbf.py:286` and `qemu.py:64` all discard the return value, so only the CLI path behaves differently.

**On `ignore_missing`**

I chose `True` there. The only caller is `helpers/image._close()`, which ignores the result, so nothing depends on it; `True` seemed the better reading of "there was no copy-on-write device, so there was nothing to roll back" — `False` would report a failure that did not happen. Happy to flip it if you read it the other way.

**What I verified, and what I could not**

Verified by driving both controllers with the subprocess calls patched out: all four methods return `True` on the normal path and on `ignore_missing`. `flake8` is clean with the exclusions from `tox.ini`.

I could not run `scripts/test-using-docker` here: the `archlinux` image has no `linux/arm64` manifest, and `mtda-service` imports `systemd`, which is not installable on macOS. So this rests on reading the call chain and on the isolated check above rather than on the integration suite — worth a second look on that account.

I did not add a test. The suite is integration-based against a live service, and the docker backend has no `rollback` to exercise. If you would like one, I am glad to add it in whatever shape fits.
