### PR TITLE
power: return the unsure state from the shellcmd driver

### DIFF
--- a/mtda/power/shellcmd.py
+++ b/mtda/power/shellcmd.py
@@ -70,7 +70,7 @@ class ShellCmdPowerController(PowerController):
         elif proc.returncode == 1:
             return self.POWER_OFF
         else:
-            self.POWER_UNSURE
+            return self.POWER_UNSURE
 
     def toggle(self):
         s = self.status()


### PR DESCRIPTION
`docs/config.rst` describes `check-on` as:

> Should return 0 if power is on, 1 if it is off. Any other return code is interpreted as error.

The error branch in `ShellCmdPowerController.status()` evaluates `self.POWER_UNSURE` without returning it, so the method falls through and yields `None`.

That `None` reaches the user rather than staying internal. `grpc/servicer.py:478` sends `str(result or '')`, so `mtda-cli target status` prints an empty line where the documentation says it should report an unknown state.

Driving the controller with `subprocess.run` patched, before and after:

```
check-on exit=  0   ON     -> 'ON'
check-on exit=  1   OFF    -> 'OFF'
check-on exit=  2   None   -> ''      after: '???'
check-on exit=127   None   -> ''      after: '???'
```

The change is the missing `return`.

I scanned the rest of the tree with the AST for the same shape — a bare `self.X` expression statement where a `return` was meant — and this is the only occurrence.

`flake8` is clean with the exclusions from `tox.ini`. I could not run `scripts/test-using-docker` here (the `archlinux` image has no `linux/arm64` manifest, and `mtda-service` imports `systemd`, which is not installable on macOS), so this rests on the isolated check above.

Found while looking at #596, which turns out to be already fixed by 9b2890e — the documentation now reads correctly, but the code no longer matches it in this one branch. Worth closing #596 if it was left open by oversight.
