### PR TITLE
fix(console): join rx_thread in stop() before returning

### DIFF
--- a/mtda/console/output.py
+++ b/mtda/console/output.py
@@ -61,6 +61,15 @@ class ConsoleOutput:
     def stop(self):
         self.exiting = True
 
+    def join(self, timeout=None):
+        """Wait for the rx thread to actually exit. A subclass whose
+        reader() blocks on something stop() alone can't interrupt (a
+        socket, a streaming RPC) should unblock it first, then call this,
+        so a caller relying on stop() to mean "actually stopped" -- not
+        just "told to stop" -- gets that guarantee."""
+        if self.rx_thread is not None:
+            self.rx_thread.join(timeout=timeout)
+
     def toggle(self):
         with self.rx_lock:
             if self.rx_paused is True:

--- a/mtda/console/remote.py
+++ b/mtda/console/remote.py
@@ -106,6 +106,13 @@ class RemoteConsole(ConsoleOutput):
         if self._channel is not None:
             self._channel.close()
             self._channel = None
+        # cancel()+close() above only request the reader thread's blocking
+        # 'for msg in self._stream' to unblock -- join() so stop() doesn't
+        # return until it actually has. A caller that forks right after
+        # stop() would otherwise race grpc-core's own thread pool, which
+        # won't report idle to that fork while this channel is still
+        # mid-teardown.
+        self.join(timeout=5)
 
 
 class RemoteMonitor(RemoteConsole):


### PR DESCRIPTION
ConsoleOutput.stop() only flipped exiting=True; the rx thread it started in start() could still be alive well after stop() returned, since nothing ever joined it. For RemoteConsole, that thread blocks on a streaming RPC's grpc channel -- a caller that treats stop() as "the channel is gone" and forks right after races grpc-core's own thread pool, which won't report idle to that fork while the channel is still mid-teardown, and stalls with "Waiting for thread pool to idle before forking".

ConsoleOutput gains join(timeout=None), and RemoteConsole.stop() calls it after cancelling its stream and closing its channel, so stop() doesn't return until the thread has actually exited.